### PR TITLE
fix: aliases for minified external functions

### DIFF
--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -39,16 +39,35 @@ function buildSandboxedWidget({ id, scriptSrc, widgetProps }: { id: string, scri
           const callbacks = {};
           const requests = {};
 
-          const buildRequest = ${buildRequest.toString()};
-          const postMessage = ${postMessage.toString()};
-          const postWidgetRenderMessage = ${postWidgetRenderMessage.toString()};
-          const postCallbackInvocationMessage = ${postCallbackInvocationMessage.toString()};
-          const postCallbackResponseMessage = ${postCallbackResponseMessage.toString()};
+          ${buildRequest.toString()}
+          ${postMessage.toString()}
+          ${postWidgetRenderMessage.toString()}
+          ${postCallbackInvocationMessage.toString()}
+          ${postCallbackResponseMessage.toString()}
 
-          const deserializeProps = ${deserializeProps.toString()};
-          const serializeArgs = ${serializeArgs.toString()};
-          const serializeNode = ${serializeNode.toString()};
-          const serializeProps = ${serializeProps.toString()};
+          ${deserializeProps.toString()}
+          ${serializeArgs.toString()}
+          ${serializeNode.toString()}
+          ${serializeProps.toString()}
+
+          ${function () {
+            const inlinedFunctions = {
+              buildRequest: buildRequest.name,
+              deserializeProps: deserializeProps.name,
+              postCallbackInvocationMessage: postCallbackInvocationMessage.name,
+              postCallbackResponseMessage: postCallbackResponseMessage.name,
+              postMessage: postMessage.name,
+              postWidgetRenderMessage: postWidgetRenderMessage.name,
+              serializeArgs: serializeArgs.name,
+              serializeNode: serializeNode.name,
+              serializeProps: serializeProps.name,
+            };
+
+            return Object.entries(inlinedFunctions)
+              .filter(([functionName, minifiedName]) => functionName !== minifiedName)
+              .map(([functionName, minifiedName]) => 'if (!' + functionName + ') { window.' + functionName + ' = ' + minifiedName + '; }')
+              .join('\n');
+          }()}
 
           let lastRenderedNode;
           // FIXME circular dependency between [dispatchRenderEvent] (referenced in Preact fork) and [h] (used to render builtin components) 


### PR DESCRIPTION
This PR adds aliases for external functions whose definitions are inlined into the iframe container. Since external functions are minified before deployment, they will have one-character names in their definitions and within references to each other. Other Component container code refers to them by their original names, so these external functions must be addressable by either the minified or original name.

In development mode, the functions are not minified and therefore do not require aliases. Therefore the assignment of aliases is dynamic based on whether the original name is being used.