### PR TITLE
fix: update regex to reference createElement

### DIFF
--- a/apps/web/pages/transpiler.tsx
+++ b/apps/web/pages/transpiler.tsx
@@ -92,7 +92,7 @@ export default function Transpiler() {
     }
 
     function parseChildWidgetPaths(transpiledWidget) {
-      const widgetRegex = /h\\(Widget,\\s*\\{(?:[\w\W]*?)(?:\\s*src:\\s+["|'](?<src>[\\w\\d_]+\\.near\\/widget\\/[\\w\\d_.]+))["|']/ig;
+      const widgetRegex = /createElement\\(Widget,\\s*\\{(?:[\w\W]*?)(?:\\s*src:\\s+["|'](?<src>[\\w\\d_]+\\.near\\/widget\\/[\\w\\d_.]+))["|']/ig;
       const matches = [...(transpiledWidget.matchAll(widgetRegex))]
         .reduce((widgetInstances, match) => {
           const source = match.groups.src;


### PR DESCRIPTION
This PR fixes a regression in trusted loading from #37 . Now that the transpiled code references `createElement` rather than `h`, the regex for parsing Component trees must reference the new method name.