### PR TITLE
feat: explicit Component IDs

### DIFF
--- a/apps/web/hooks/useComponentMetrics.ts
+++ b/apps/web/hooks/useComponentMetrics.ts
@@ -1,0 +1,32 @@
+import type {
+  WidgetUpdate,
+} from '@bos-web-engine/application';
+import type {
+  PostMessageWidgetCallbackInvocation,
+  PostMessageWidgetCallbackResponse,
+  PostMessageWidgetRender,
+} from '@bos-web-engine/container';
+import { useState } from 'react';
+
+export function useComponentMetrics() {
+  const [callbackInvocations, setCallbackInvocations] = useState<PostMessageWidgetCallbackInvocation[]>([]);
+  const [callbackResponses, setCallbackResponses] = useState<PostMessageWidgetCallbackResponse[]>([]);
+  const [componentRenders, setComponentRenders] = useState<PostMessageWidgetRender[]>([]);
+  const [componentUpdates, setComponentUpdates] = useState<WidgetUpdate[]>([]);
+  const [missingComponents, setMissingComponents] = useState<string[]>([]);
+
+  return {
+    metrics: {
+      callbackInvocations,
+      callbackResponses,
+      componentRenders,
+      componentUpdates,
+      missingComponents,
+    },
+    callbackInvoked: (callback: PostMessageWidgetCallbackInvocation) => setCallbackInvocations((current) => [...current, callback]),
+    callbackReturned: (response: PostMessageWidgetCallbackResponse) => setCallbackResponses((current) => [...current, response]),
+    componentMissing: (componentId: string) => setMissingComponents((current) => [...current, componentId]),
+    componentRendered: (component: PostMessageWidgetRender) => setComponentRenders((current) => [...current, component]),
+    componentUpdated: (component: WidgetUpdate) => setComponentUpdates((current) => [...current, component]),
+  };
+}

--- a/apps/web/hooks/useWebEngine.ts
+++ b/apps/web/hooks/useWebEngine.ts
@@ -78,7 +78,7 @@ export function useWebEngine({ showWidgetDebug, rootComponentPath }: UseWebEngin
     }
 
     domRoots.current[widgetId].render(element);
-  }, [domRoots]);
+  }, [domRoots, componentMissing]);
 
   const processMessage = useCallback((event: any) => {
     try {
@@ -120,7 +120,7 @@ export function useWebEngine({ showWidgetDebug, rootComponentPath }: UseWebEngin
     } catch (e) {
       console.error({ event }, e);
     }
-  }, [showWidgetDebug, components, loadComponent, mountElement]);
+  }, [showWidgetDebug, components, loadComponent, mountElement, getComponentRenderCount, renderComponent, callbackInvoked, callbackReturned, componentRendered, componentUpdated]);
 
   useEffect(() => {
     window.addEventListener('message', processMessage);
@@ -151,7 +151,7 @@ export function useWebEngine({ showWidgetDebug, rootComponentPath }: UseWebEngin
         isTrusted: false,
       });
     }
-  }, [rootComponentPath, rootComponentSource, compiler]);
+  }, [rootComponentPath, rootComponentSource, compiler, addComponent, components]);
 
   return {
     components,

--- a/apps/web/hooks/useWebEngine.ts
+++ b/apps/web/hooks/useWebEngine.ts
@@ -8,7 +8,7 @@ import {
 } from '@bos-web-engine/application';
 import type { ComponentCompilerResponse } from '@bos-web-engine/compiler';
 import { getAppDomId } from '@bos-web-engine/iframe';
-import { useCallback, useEffect, useState } from 'react';
+import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 
 interface UseWebEngineParams {
@@ -22,7 +22,7 @@ export function useWebEngine({ monitor, showWidgetDebug, rootComponentPath }: Us
   const [components, setComponents] = useState<{ [key: string]: any }>({});
   const [rootComponentSource, setRootComponentSource] = useState<string | null>(null);
 
-  const domRoots: { [key: string]: ReactDOM.Root } = {};
+  const domRoots: MutableRefObject<{ [key: string]: ReactDOM.Root }> = useRef({});
 
   const addComponent = useCallback((componentId: string, component: any) => {
     setComponents((currentComponents) => ({
@@ -38,10 +38,10 @@ export function useWebEngine({ monitor, showWidgetDebug, rootComponentPath }: Us
 
     addComponent(componentId, component);
     compiler?.postMessage({ componentId, isTrusted: component.isTrusted });
-  }, [compiler, components]);
+  }, [compiler, components, addComponent]);
 
-  const mountElement = ({ widgetId, element }: { widgetId: string, element: WidgetDOMElement }) => {
-    if (!domRoots[widgetId]) {
+  const mountElement = useCallback(({ widgetId, element }: { widgetId: string, element: WidgetDOMElement }) => {
+    if (!domRoots.current[widgetId]) {
       const domElement = document.getElementById(getAppDomId(widgetId));
       if (!domElement) {
         const metricKey = widgetId.split('##')[0];
@@ -50,54 +50,55 @@ export function useWebEngine({ monitor, showWidgetDebug, rootComponentPath }: Us
         return;
       }
 
-      domRoots[widgetId] = ReactDOM.createRoot(domElement);
+      domRoots.current[widgetId] = ReactDOM.createRoot(domElement);
     }
 
-    domRoots[widgetId].render(element);
-  };
+    domRoots.current[widgetId].render(element);
+  }, [domRoots, monitor]);
+
+  const processMessage = useCallback((event: any) => {
+    try {
+      if (typeof event.data !== 'object') {
+        return;
+      }
+
+      const { data } = event;
+      switch (data.type) {
+        case 'widget.callbackInvocation': {
+          console.log('invoked!')
+          monitor.widgetCallbackInvoked(data);
+          onCallbackInvocation({ data });
+          break;
+        }
+        case 'widget.callbackResponse': {
+          monitor.widgetCallbackReturned(data);
+          onCallbackResponse({ data });
+          break;
+        }
+        case 'widget.render': {
+          monitor.widgetRendered(data);
+          onRender({
+            data,
+            isDebug: showWidgetDebug,
+            markWidgetUpdated: (update: WidgetUpdate) => monitor.widgetUpdated(update),
+            mountElement,
+            loadComponent: (component) => loadComponent(component.componentId, component),
+            isComponentLoaded: (c: string) => !!components[c],
+          });
+          break;
+        }
+        default:
+          break;
+      }
+    } catch (e) {
+      console.error({ event }, e);
+    }
+  }, [showWidgetDebug, components, loadComponent, mountElement, monitor]);
 
   useEffect(() => {
-    function processMessage(event: any) {
-      try {
-        if (typeof event.data !== 'object') {
-          return;
-        }
-
-        const { data } = event;
-        switch (data.type) {
-          case 'widget.callbackInvocation': {
-            monitor.widgetCallbackInvoked(data);
-            onCallbackInvocation({ data });
-            break;
-          }
-          case 'widget.callbackResponse': {
-            monitor.widgetCallbackReturned(data);
-            onCallbackResponse({ data });
-            break;
-          }
-          case 'widget.render': {
-            monitor.widgetRendered(data);
-            onRender({
-              data,
-              isDebug: showWidgetDebug,
-              markWidgetUpdated: (update: WidgetUpdate) => monitor.widgetUpdated(update),
-              mountElement,
-              loadComponent: (component) => loadComponent(component.componentId, component),
-              isComponentLoaded: (c: string) => !!components[c],
-            });
-            break;
-          }
-          default:
-            break;
-        }
-      } catch (e) {
-        console.error({ event }, e);
-      }
-    }
-
     window.addEventListener('message', processMessage);
     return () => window.removeEventListener('message', processMessage);
-  }, [rootComponentSource, showWidgetDebug]);
+  }, [processMessage]);
 
   useEffect(() => {
     if (!rootComponentPath) {

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,15 +1,12 @@
 import {
-  WidgetActivityMonitor,
-  WidgetMonitor,
+  ComponentMonitor,
 } from '@bos-web-engine/application';
 import { getAppDomId, getIframeId, SandboxedIframe } from '@bos-web-engine/iframe';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { useWebEngine } from '../hooks';
 
 const DEFAULT_ROOT_WIDGET = 'andyh.near/widget/MainPage';
-
-const monitor = new WidgetActivityMonitor();
 
 export default function Web() {
   const [rootComponentPath, setRootComponentPath] = useState('');
@@ -17,8 +14,7 @@ export default function Web() {
   const [showMonitor, setShowMonitor] = useState(true);
   const [showWidgetDebug, setShowWidgetDebug] = useState(true);
 
-  const { components } = useWebEngine({
-    monitor,
+  const { components, metrics } = useWebEngine({
     showWidgetDebug,
     rootComponentPath,
   });
@@ -58,7 +54,7 @@ export default function Web() {
       )}
       {rootComponentPath && (
         <>
-          {showMonitor && <WidgetMonitor monitor={monitor} />}
+          {showMonitor && <ComponentMonitor metrics={metrics} components={Object.values(components)} />}
           <div id={getAppDomId(rootComponentPath)} className='iframe'>
             root widget goes here
           </div>

--- a/packages/application/src/handlers.ts
+++ b/packages/application/src/handlers.ts
@@ -50,6 +50,13 @@ export function onCallbackResponse({
   });
 }
 
+interface ChildComponent {
+  widgetId: string;
+  props: any;
+  source: string;
+  isTrusted: boolean;
+}
+
 export function onRender({
   data,
   isDebug = false,
@@ -67,7 +74,11 @@ export function onRender({
   const element = createElement({
     children: [
       ...(isDebug ? [
-        React.createElement('span', { className: 'dom-label' }, `[${widgetId.split('##')[0]} (${getComponentRenderCount(widgetId)})]`),
+        React.createElement(
+          'span',
+          { className: 'dom-label' },
+          `[${widgetId.split('##')[0]} (${getComponentRenderCount(widgetId)})]`
+        ),
         React.createElement('br'),
       ] : []),
       ...(Array.isArray(componentChildren) ? componentChildren : [componentChildren]),
@@ -79,7 +90,7 @@ export function onRender({
   mountElement({ widgetId, element });
   markWidgetUpdated({ props, widgetId });
 
-  childWidgets.forEach(({ widgetId: childWidgetId, props: widgetProps, source, isTrusted }: { widgetId: string, props: any, source: string, isTrusted: boolean }) => {
+  childWidgets.forEach(({ widgetId: childWidgetId, props: widgetProps, source, isTrusted }: ChildComponent) => {
     /*
       a new Component is being rendered by a parent Component, either:
       - this Component is being loaded for the first time

--- a/packages/application/src/handlers.ts
+++ b/packages/application/src/handlers.ts
@@ -53,6 +53,7 @@ export function onCallbackResponse({
 export function onRender({
   data,
   isDebug = false,
+  getComponentRenderCount,
   markWidgetUpdated,
   mountElement,
   isComponentLoaded,
@@ -66,7 +67,7 @@ export function onRender({
   const element = createElement({
     children: [
       ...(isDebug ? [
-        React.createElement('span', { className: 'dom-label' }, `[${widgetId.split('##')[0]}]`),
+        React.createElement('span', { className: 'dom-label' }, `[${widgetId.split('##')[0]} (${getComponentRenderCount(widgetId)})]`),
         React.createElement('br'),
       ] : []),
       ...(Array.isArray(componentChildren) ? componentChildren : [componentChildren]),
@@ -79,9 +80,9 @@ export function onRender({
 
   childWidgets.forEach(({ widgetId: childWidgetId, props: widgetProps, source, isTrusted }: { widgetId: string, props: any, source: string, isTrusted: boolean }) => {
     /*
-      a widget is being rendered by a parent widget, either:
-      - this widget is being loaded for the first time
-      - the parent widget has updated and is re-rendering this widget
+      a new Component is being rendered by a parent Component, either:
+      - this Component is being loaded for the first time
+      - the parent Component has updated and is re-rendering this Component
     */
     if (!isComponentLoaded(childWidgetId)) {
       /* widget code has not yet been loaded, add to cache and load */
@@ -91,10 +92,11 @@ export function onRender({
         isTrusted,
         parentId: widgetId,
         props: widgetProps,
+        renderCount: 0,
       });
     } else {
       /* widget iframe is already loaded, post update message to iframe */
-      markWidgetUpdated({ props, widgetId });
+      markWidgetUpdated({ props, widgetId: childWidgetId });
       postMessageToWidgetIframe({
         id: childWidgetId,
         message: {

--- a/packages/application/src/handlers.ts
+++ b/packages/application/src/handlers.ts
@@ -77,6 +77,7 @@ export function onRender({
     type: node.type,
   });
   mountElement({ widgetId, element });
+  markWidgetUpdated({ props, widgetId });
 
   childWidgets.forEach(({ widgetId: childWidgetId, props: widgetProps, source, isTrusted }: { widgetId: string, props: any, source: string, isTrusted: boolean }) => {
     /*
@@ -96,7 +97,7 @@ export function onRender({
       });
     } else {
       /* widget iframe is already loaded, post update message to iframe */
-      markWidgetUpdated({ props, widgetId: childWidgetId });
+      markWidgetUpdated({ props: widgetProps, widgetId: childWidgetId });
       postMessageToWidgetIframe({
         id: childWidgetId,
         message: {

--- a/packages/application/src/handlers.ts
+++ b/packages/application/src/handlers.ts
@@ -96,7 +96,7 @@ export function onRender({
       /* widget iframe is already loaded, post update message to iframe */
       markWidgetUpdated({ props, widgetId });
       postMessageToWidgetIframe({
-        id: widgetId,
+        id: childWidgetId,
         message: {
           props: widgetProps,
           type: 'widget.update',

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -4,8 +4,7 @@ export {
   onRender,
 } from './handlers';
 export {
-  WidgetMonitor,
-  WidgetActivityMonitor,
+  ComponentMonitor,
 } from './monitor';
 export {
   createChildElements,

--- a/packages/application/src/monitor.tsx
+++ b/packages/application/src/monitor.tsx
@@ -14,6 +14,8 @@ export function ComponentMonitor({ components, metrics }: { components: any[], m
     componentsBySource[source].push(widget);
     return componentsBySource;
   }, {} as { [key: string]: Widget[] });
+  const sortedByFrequency = Object.entries(groupedComponents) as [string, Widget[]][];
+  sortedByFrequency.sort(([, aComponents], [, bComponents]) => bComponents.length - aComponents.length);
 
   return (
     <div id='widget-monitor'>
@@ -29,8 +31,7 @@ export function ComponentMonitor({ components, metrics }: { components: any[], m
       </div>
       <div className='widgets'>
         {
-          Object.entries(groupedComponents)
-            .sort(([, aComponents], [, bComponents]) => bComponents.length - aComponents.length)
+          sortedByFrequency
             .map(([source, componentsBySource], i) => (
               <div className='widget-row' key={`widget-row-${i}`}>
                 {(componentsBySource as Widget[]).length} {source}

--- a/packages/application/src/monitor.tsx
+++ b/packages/application/src/monitor.tsx
@@ -1,93 +1,39 @@
-import type {
-  PostMessageWidgetCallbackInvocation,
-  PostMessageWidgetCallbackResponse,
-  PostMessageWidgetRender,
-} from '@bos-web-engine/container';
 import React from 'react';
 
 import type {
-  DomCallback,
   Widget,
-  WidgetUpdate,
 } from './types';
 
-export class WidgetActivityMonitor {
-  callbacks: {
-    invocations: PostMessageWidgetCallbackInvocation[],
-    responses: PostMessageWidgetCallbackResponse[],
-  } = { invocations: [], responses: [] };
-  domCallbacks: DomCallback[] = [];
-  renders: PostMessageWidgetRender[] = [];
-  updates: WidgetUpdate[] = [];
-  widgets: Widget[] = [];
-  missingWidgets: string[] = [];
+export function ComponentMonitor({ components, metrics }: { components: any[], metrics: object }) {
+  const groupedComponents = components.reduce((componentsBySource, widget) => {
+    const source = widget.componentId.split('##')[0];
+    if (!componentsBySource[source]) {
+      componentsBySource[source] = [];
+    }
 
-  domCallbackInvoked(callback: DomCallback) {
-    this.domCallbacks.push(callback);
-  }
-
-  missingWidgetReferenced(widgetId: string) {
-    this.missingWidgets.push(widgetId);
-  }
-
-  widgetAdded(widget: Widget) {
-    this.widgets.push(widget);
-  }
-
-  widgetCallbackInvoked(invocation: PostMessageWidgetCallbackInvocation) {
-    this.callbacks.invocations.push(invocation);
-  }
-
-  widgetCallbackReturned(response: PostMessageWidgetCallbackResponse) {
-    this.callbacks.responses.push(response);
-  }
-
-  widgetRendered(render: PostMessageWidgetRender) {
-    this.renders.push(render);
-  }
-
-  widgetUpdated(update: WidgetUpdate) {
-    this.updates.push(update);
-  }
-}
-
-export function WidgetMonitor({ monitor }: { monitor: WidgetActivityMonitor }) {
-  const dataPoints = [
-    { label: 'widgets loaded', value: monitor.widgets.length },
-    { label: 'renders', value: monitor.renders.length },
-    { label: 'updates', value: monitor.updates.length },
-    { label: 'invocations', value: monitor.callbacks.invocations.length },
-    { label: 'responses', value: monitor.callbacks.responses.length },
-    { label: 'missing widgets', value: monitor.missingWidgets.length },
-  ];
+    componentsBySource[source].push(widget);
+    return componentsBySource;
+  }, {} as { [key: string]: Widget[] });
 
   return (
     <div id='widget-monitor'>
       <div className='metrics'>
-        {dataPoints.map(({ label, value }, i) => (
+        {Object.entries(metrics).map(([label, value], i) => (
           <div className='metrics-data-point' key={`data-point-${i}`}>
             <div className='data-point-header'>{label}</div>
             <div className='data-point-value'>
-              {value}
+              {value.length}
             </div>
           </div>
         ))}
       </div>
       <div className='widgets'>
         {
-          Object.entries(monitor.widgets.reduce((widgetsBySource, widget) => {
-            const { source } = widget;
-            if (!widgetsBySource[source]) {
-              widgetsBySource[source] = [];
-            }
-
-            widgetsBySource[source].push(widget);
-            return widgetsBySource;
-          }, {} as { [key: string]: Widget[] }))
-            .sort(([, aWidgets], [, bWidgets]) => bWidgets.length - aWidgets.length)
-            .map(([source, widgets], i) => (
+          Object.entries(groupedComponents)
+            .sort(([, aComponents], [, bComponents]) => bComponents.length - aComponents.length)
+            .map(([source, componentsBySource], i) => (
               <div className='widget-row' key={`widget-row-${i}`}>
-                {widgets.length} {source}
+                {(componentsBySource as Widget[]).length} {source}
               </div>
             ))
         }

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -31,21 +31,23 @@ export interface CallbackResponseHandlerOptions {
   data: CallbackResponseEventData;
 }
 
-interface LoadComponentParams {
+export interface ComponentInstance {
   componentId: string;
   componentPath: string;
   isTrusted: boolean;
   parentId: string;
   props: any;
+  renderCount: number;
 }
 
 export interface RenderHandlerOptions {
   data: RenderEventData;
   isDebug?: boolean;
+  getComponentRenderCount: (componentId: string) => number;
   markWidgetUpdated: (update: WidgetUpdate) => void;
   mountElement: ({ widgetId, element }: { widgetId: string, element: any }) => void;
   isComponentLoaded(componentId: string): boolean;
-  loadComponent(component: LoadComponentParams): void;
+  loadComponent(component: ComponentInstance): void;
 }
 
 export interface IframePostMessageOptions {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -33,7 +33,7 @@ interface ParseComponentTreeParams {
 
 export class ComponentCompiler {
   private bosSourceCache: Map<string, Promise<string>>;
-  private compiledSourceCache: Map<string, string>;
+  private compiledSourceCache: Map<string, string | null>;
   private readonly sendMessage: SendMessageCallback;
 
   constructor({ sendMessage }: ComponentCompilerOptions) {
@@ -68,8 +68,13 @@ export class ComponentCompiler {
   getTranspiledComponentSource({ componentPath, componentSource, isRoot }: TranspiledComponentLookupParams) {
     const cacheKey = JSON.stringify({ componentPath, isRoot });
     if (!this.compiledSourceCache.has(cacheKey)) {
-      const { code } = transpileSource(componentSource);
-      this.compiledSourceCache.set(cacheKey, code);
+      try {
+        const { code } = transpileSource(componentSource);
+        this.compiledSourceCache.set(cacheKey, code);
+      } catch (e) {
+        console.error(`Failed to transpile ${componentPath}`, e);
+        this.compiledSourceCache.set(cacheKey, null);
+      }
     }
 
     return this.compiledSourceCache.get(cacheKey)!;

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -22,11 +22,10 @@ interface BuildComponentFunctionParams {
 export function buildComponentFunction({ componentPath, componentSource, isRoot }: BuildComponentFunctionParams) {
   const componentBody = '\n\n/*' + componentPath + '*/\n\n' + componentSource;
 
-  const stateInitialization = 'const { state, State} = (' + initializeComponentState.toString() + ')(ComponentState, "' + componentPath + '");';
+  const stateInitialization = 'const { state, State} = (' + initializeComponentState.toString() + ')(ComponentState, "' + componentPath + '", renderWidget);';
   if (isRoot) {
     return `
       function ${buildComponentFunctionName()}() {
-        const ComponentState = new Map();
         ${stateInitialization}
         ${componentBody}
       }
@@ -41,17 +40,16 @@ export function buildComponentFunction({ componentPath, componentSource, isRoot 
   `;
 }
 
-function initializeComponentState(ComponentState: ComponentStateMap, componentInstanceId: string) {
-  const buildSafeProxyFromMap = (map: ComponentStateMap, widgetId: string) => new Proxy({}, {
+function initializeComponentState(ComponentState: ComponentStateMap, componentInstanceId: string, renderWidget: () => void) {
+  const state = new Proxy({}, {
     get(_, key) {
       try {
-        return map.get(widgetId)?.[key];
+        return ComponentState.get(componentInstanceId)?.[key];
       } catch {
         return undefined;
       }
     },
   });
-
   const State = {
     init(obj: any) {
       if (!ComponentState.has(componentInstanceId)) {
@@ -60,11 +58,12 @@ function initializeComponentState(ComponentState: ComponentStateMap, componentIn
     },
     update(newState: any, initialState = {}) {
       ComponentState.set(componentInstanceId, Object.assign(initialState, ComponentState.get(componentInstanceId), newState));
+      renderWidget();
     },
   };
 
   return {
-    state: buildSafeProxyFromMap(ComponentState, componentInstanceId),
+    state,
     State,
   };
 }

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -84,8 +84,8 @@ function initializeComponentState({
     },
     update(newState: any, initialState = {}) {
       ComponentState.set(componentInstanceId, Object.assign(initialState, ComponentState.get(componentInstanceId), newState));
-      /* @ts-expect-error */
-      dispatchRenderEvent(componentFunction({ props: componentProps }), componentInstanceId, true);
+      // FIXME need to debug empty renders
+      // dispatchRenderEvent(componentFunction({ props: componentProps }), componentInstanceId);
     },
   };
 

--- a/packages/container/src/hooks.ts
+++ b/packages/container/src/hooks.ts
@@ -13,7 +13,7 @@ export function buildUseComponentCallback(renderComponent: () => void) {
       }
 
       callbackMap.set(key, undefined);
-      callback(...args)
+      Promise.resolve(callback(...args))
         .then((res) => {
           callbackMap.set(key, res);
           renderComponent();

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -273,16 +273,22 @@ export function serializeNode({ builtinComponents, node, index, childWidgets, ca
         return node;
       }
 
+      const componentId = buildWidgetId({
+        instanceId: props?.id,
+        widgetPath: props.src,
+        widgetProps: props?.props,
+        parentWidgetId: parentId,
+      });
+
       return {
         ...node,
         props: {
           ...node.props,
-          id: 'dom-' + buildWidgetId({
-            instanceId: props?.id,
-            widgetPath: type.name,
-            widgetProps: props?.props,
-            parentWidgetId: parentId,
-          }),
+          __bweMeta: {
+            ...node.props?.__bweMeta,
+            componentId,
+          },
+          id: 'dom-' + componentId,
         },
       };
     }

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -255,6 +255,9 @@ export function serializeNode({ builtinComponents, node, index, childWidgets, ca
         type: 'div',
         props: {
           id: 'dom-' + widgetId,
+          __bweMeta: {
+            componentId: widgetId,
+          },
         },
       };
     } else {

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -203,8 +203,9 @@ export function serializeNode({ builtinComponents, node, index, childWidgets, ca
     return node;
   }
 
-  let { type } = node;
-  const { children } = node.props;
+  const { type } = node;
+  let serializedElementType = typeof type === 'string' ? type : '';
+  const children = node?.props?.children || [];
   let props = { ...node.props };
   delete props.children;
 
@@ -219,23 +220,23 @@ export function serializeNode({ builtinComponents, node, index, childWidgets, ca
     });
 
   if (!type) {
-    type = 'div';
+    serializedElementType = 'div';
   } else if (typeof type === 'function') {
     const { name: component } = type;
     if (component === '_') {
-      type = 'div';
+      serializedElementType = 'div';
       // @ts-expect-error
     } else if (builtinComponents[component]) {
       // @ts-expect-error
       const builtin = builtinComponents[component];
       ({
         props,
-        type,
+        type: serializedElementType,
       } = builtin({
         children: unifiedChildren,
         props,
       }));
-      unifiedChildren = props.children;
+      unifiedChildren = props.children || [];
     } else if (component === 'Widget') {
       const { id: instanceId, src, props: widgetProps, isTrusted } = props;
       const widgetId = buildWidgetId({ instanceId, widgetPath: src, widgetProps, parentWidgetId: parentId });
@@ -288,7 +289,7 @@ export function serializeNode({ builtinComponents, node, index, childWidgets, ca
   }
 
   return {
-    type,
+    type: serializedElementType,
     props: {
       ...serializeProps({ props, builtinComponents, callbacks, parentId }),
       children: unifiedChildren

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -1,5 +1,10 @@
 export type Args = Array<Cloneable>;
 
+interface WebEngineMeta {
+  componentId?: string;
+  isProxy?: boolean;
+}
+
 export type BuildRequestCallback = () => CallbackRequest;
 
 export interface CallbackRequest {
@@ -280,6 +285,7 @@ export interface SerializedWidgetCallback {
 }
 
 export interface WidgetProps {
+  __bweMeta?: WebEngineMeta;
   children?: any[];
   id: string;
 }

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -239,9 +239,14 @@ export interface BuiltinComponents {
   Typeahead: CreateSerializedBuiltin;
 }
 
+export interface Node {
+  type: string | Function;
+  props?: NodeProps;
+}
+
 export interface SerializeNodeOptions {
   builtinComponents: BuiltinComponents;
-  node: any;
+  node: Node;
   index: number;
   childWidgets: any[];
   callbacks: CallbackMap;

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -117,7 +117,7 @@ function buildSandboxedWidget({ id, isTrusted, scriptSrc, widgetProps }: Sandbox
 
           /* NS shims */
           function buildSafeProxy(p) {
-            return new Proxy({ ...p, __bweMeta: { isProxy: true } }, {
+            return new Proxy({ ...p, __bweMeta: { componentId: '${id}', isProxy: true } }, {
               get(target, key) {
                 try {
                   return target[key];                

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -171,6 +171,8 @@ function buildSandboxedWidget({ id, isTrusted, scriptSrc, widgetProps }: Sandbox
 
           // TODO remove debug value
           const context = buildSafeProxy({ accountId: props.accountId || 'andyh.near' });
+          
+          const ComponentState = new Map();
 
           function WidgetWrapper() {
             try {

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -217,6 +217,7 @@ function buildSandboxedWidget({ id, isTrusted, scriptSrc, widgetProps }: Sandbox
           function isMatchingProps(props, compareProps) {
             const getComparable = (p) => Object.keys(p)
               .sort()
+              .filter((k) => k !== '__bweMeta')
               .map((propKey) => propKey + '::' + p[propKey])
               .join(',');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,9 @@ importers:
     specifiers:
       '@babel/core': ^7.0.0
       '@bos-web-engine/application': workspace:*
+      '@bos-web-engine/compiler': workspace:*
       '@bos-web-engine/container': workspace:*
       '@bos-web-engine/iframe': workspace:*
-      '@bos-web-engine/compiler': workspace:*
       '@types/node': ^17.0.12
       '@types/react': ^18.0.22
       '@types/react-dom': ^18.0.7
@@ -40,9 +40,9 @@ importers:
       uuid: ^9.0.0
     dependencies:
       '@bos-web-engine/application': link:../../packages/application
+      '@bos-web-engine/compiler': link:../../packages/compiler
       '@bos-web-engine/container': link:../../packages/container
       '@bos-web-engine/iframe': link:../../packages/iframe
-      '@bos-web-engine/compiler': link:../../packages/compiler
       next: 13.4.13_w4exofnty45araakomg6jes2wu
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -83,6 +83,31 @@ importers:
       eslint: 7.32.0
       eslint-config-custom: link:../eslint-config-custom
       react: 18.2.0
+      tsconfig: link:../tsconfig
+      typescript: 4.9.5
+
+  packages/compiler:
+    specifiers:
+      '@babel/standalone': ^7.22.14
+      '@bos-web-engine/container': workspace:*
+      '@near-js/providers': ^0.0.7
+      '@near-js/types': ^0.0.4
+      '@types/babel__standalone': ^7.1.4
+      '@types/node': ^17.0.12
+      eslint: ^7.32.0
+      eslint-config-custom: workspace:*
+      tsconfig: workspace:*
+      typescript: ^4.5.2
+    dependencies:
+      '@babel/standalone': 7.22.14
+      '@bos-web-engine/container': link:../container
+      '@near-js/providers': 0.0.7
+    devDependencies:
+      '@near-js/types': 0.0.4
+      '@types/babel__standalone': 7.1.4
+      '@types/node': 17.0.45
+      eslint: 7.32.0
+      eslint-config-custom: link:../eslint-config-custom
       tsconfig: link:../tsconfig
       typescript: 4.9.5
 
@@ -145,31 +170,6 @@ importers:
       eslint: 7.32.0
       eslint-config-custom: link:../eslint-config-custom
       react: 18.2.0
-      tsconfig: link:../tsconfig
-      typescript: 4.9.5
-
-  packages/compiler:
-    specifiers:
-      '@babel/standalone': ^7.22.14
-      '@bos-web-engine/container': workspace:*
-      '@near-js/providers': ^0.0.7
-      '@near-js/types': ^0.0.4
-      '@types/babel__standalone': ^7.1.4
-      '@types/node': ^17.0.12
-      eslint: ^7.32.0
-      eslint-config-custom: workspace:*
-      tsconfig: workspace:*
-      typescript: ^4.5.2
-    dependencies:
-      '@babel/standalone': 7.22.14
-      '@bos-web-engine/container': link:../container
-      '@near-js/providers': 0.0.7
-    devDependencies:
-      '@near-js/types': 0.0.4
-      '@types/babel__standalone': 7.1.4
-      '@types/node': 17.0.45
-      eslint: 7.32.0
-      eslint-config-custom: link:../eslint-config-custom
       tsconfig: link:../tsconfig
       typescript: 4.9.5
 


### PR DESCRIPTION
This PR adds a new `Widget` prop, `id`, intended to explicitly identify the Component:
```jsx
<Widget src="a.near/widget/ChildComponent" id="A" />
<Widget src="a.near/widget/ChildComponent" id="B />
```

This fixes #13.

Included in this PR are fixes for unrelated issues around state and metrics that were bugging me so I've included their fixes here as well. I tried to fix the regressions around state management but ultimately settled on temporarily disabling re-renders based on state changes. Sandboxed loading is now mostly unaffected but trusted loading is not handling state correctly as it is not distinguishing between instances of the same Component. I'll have follow up PRs to address these issues but want to truncate this one here.