### PR TITLE
feat: state enhancements and fixes

### DIFF
--- a/apps/web/hooks/useWebEngine.ts
+++ b/apps/web/hooks/useWebEngine.ts
@@ -104,11 +104,11 @@ export function useWebEngine({ showWidgetDebug, rootComponentPath }: UseWebEngin
             data,
             getComponentRenderCount,
             isDebug: showWidgetDebug,
-            markWidgetUpdated: (update: WidgetUpdate) => {
-              componentUpdated(update);
-              renderComponent(update.widgetId);
+            markWidgetUpdated: componentUpdated,
+            mountElement: ({ widgetId, element }) => {
+              renderComponent(widgetId);
+              mountElement({ widgetId, element });
             },
-            mountElement,
             loadComponent: (component) => loadComponent(component.componentId, component),
             isComponentLoaded: (c: string) => !!components[c],
           });

--- a/packages/application/src/monitor.tsx
+++ b/packages/application/src/monitor.tsx
@@ -6,7 +6,7 @@ import type {
 
 export function ComponentMonitor({ components, metrics }: { components: any[], metrics: object }) {
   const groupedComponents = components.reduce((componentsBySource, widget) => {
-    const source = widget.componentId.split('##')[0];
+    const source = widget.componentId?.split('##')[0];
     if (!componentsBySource[source]) {
       componentsBySource[source] = [];
     }

--- a/packages/application/src/widget-container.ts
+++ b/packages/application/src/widget-container.ts
@@ -15,7 +15,12 @@ export function postMessageToWidgetIframe({ id, message, targetOrigin }: IframeP
 }
 
 export function deserializeProps({ id, props }: DeserializePropsOptions): any {
-  if (!props || !props.__domcallbacks) {
+  if (!props) {
+    return props;
+  }
+
+  delete props.__bweMeta;
+  if (!props.__domcallbacks) {
     return props;
   }
 

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -21,40 +21,36 @@ interface BuildComponentFunctionParams {
 
 export function buildComponentFunction({ componentPath, componentSource, isRoot }: BuildComponentFunctionParams) {
   const functionName = buildComponentFunctionName(isRoot ? '' : componentPath);
-  const componentBody = `
-/************************* ${componentPath} *************************/
-${componentSource}
-`;
-
-  const stateInitialization =  `
-    const { state, State } = (
-      ${initializeComponentState.toString()}
-    )({
-      ComponentState,
-      componentInstanceId,
-    });
-  `;
 
   if (isRoot) {
     return `
       function ${functionName}() {
-        const componentInstanceId = props?.__bweMeta?.componentId;
-        ${stateInitialization}
-        ${componentBody}
+        const { state, State } = (
+          ${initializeComponentState.toString()}
+        )({
+          ComponentState,
+          componentInstanceId: props?.__bweMeta?.componentId,
+        });
+        ${componentSource}
       }
     `;
   }
 
   return `
+    /************************* ${componentPath} *************************/
     function ${functionName}(__bweInlineComponentProps) {
       const { props } = __bweInlineComponentProps;
-      const componentInstanceId = [
-        '${componentPath}',
-        __bweInlineComponentProps.id,
-        __bweInlineComponentProps.__bweMeta?.parentMeta?.componentId,
-      ].filter((c) => c !== undefined).join('##');
-      ${stateInitialization}
-      ${componentBody}
+      const { state, State } = (
+        ${initializeComponentState.toString()}
+      )({
+        ComponentState,
+        componentInstanceId: [
+          '${componentPath}',
+          __bweInlineComponentProps.id,
+          __bweInlineComponentProps.__bweMeta?.parentMeta?.componentId,
+        ].filter((c) => c !== undefined).join('##'),
+      });
+      ${componentSource}
     }
   `;
 }

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -1,5 +1,3 @@
-import type { WebEngineMeta } from '@bos-web-engine/container';
-
 type ComponentStateMap = Map<string, { [key: string | symbol]: any }>;
 
 /**

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -29,27 +29,18 @@ ${componentSource}
 `;
 
   const stateInitialization =  `
-    const componentInstanceId = props?.__bweMeta?.componentId || [
-      '${componentPath}',
-      typeof id !== 'undefined' ? id : undefined,
-      __bweMeta?.parentMeta?.componentId,
-    ].filter((c) => c !== undefined).join('##');
-
     const { state, State } = (
       ${initializeComponentState.toString()}
     )({
       ComponentState,
       componentInstanceId,
-      componentFunction: ${functionName},
-      componentProps: props,
-      dispatchRenderEvent,
-      __bweMeta: typeof __bweMeta === 'undefined' ? props.__bweMeta : __bweMeta,
     });
   `;
 
   if (isRoot) {
     return `
       function ${functionName}() {
+        const componentInstanceId = props?.__bweMeta?.componentId;
         ${stateInitialization}
         ${componentBody}
       }
@@ -57,34 +48,27 @@ ${componentSource}
   }
 
   return `
-    function ${functionName}({ id, props, __bweMeta }) {
+    function ${functionName}(__bweInlineComponentProps) {
+      const { props } = __bweInlineComponentProps;
+      const componentInstanceId = [
+        '${componentPath}',
+        __bweInlineComponentProps.id,
+        __bweInlineComponentProps.__bweMeta?.parentMeta?.componentId,
+      ].filter((c) => c !== undefined).join('##');
       ${stateInitialization}
       ${componentBody}
     }
   `;
 }
 
-interface ComponentFunctionProps {
-  props: object;
-  __bweMeta: WebEngineMeta;
-}
-
 interface InitializeComponentStateParams {
-  __bweMeta: WebEngineMeta;
   ComponentState: ComponentStateMap;
   componentInstanceId: string;
-  componentFunction: (props: ComponentFunctionProps) => Node;
-  componentProps: any;
-  dispatchRenderEvent: (node: Node, componentId: string) => void;
 }
 
 function initializeComponentState({
-  __bweMeta,
   ComponentState,
   componentInstanceId,
-  componentFunction,
-  componentProps,
-  dispatchRenderEvent,
 }: InitializeComponentStateParams) {
   const state = new Proxy({}, {
     get(_, key) {

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -31,7 +31,7 @@ ${componentSource}
   const stateInitialization =  `
     const componentInstanceId = props?.__bweMeta?.componentId || [
       '${componentPath}',
-      props?.id,
+      typeof id !== 'undefined' ? id : undefined,
       __bweMeta?.parentMeta?.componentId,
     ].filter((c) => c !== undefined).join('##');
 
@@ -103,14 +103,6 @@ function initializeComponentState({
     },
     update(newState: any, initialState = {}) {
       ComponentState.set(componentInstanceId, Object.assign(initialState, ComponentState.get(componentInstanceId), newState));
-      try {
-        dispatchRenderEvent(componentFunction({
-          props: componentProps,
-          __bweMeta,
-        }), componentInstanceId);
-      } catch (e) {
-        console.error(`Failed to dispatch render for ${componentInstanceId}`, e);
-      }
     },
   };
 

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -9,7 +9,10 @@ export function parseChildComponentPaths(transpiledWidget: string) {
       const source = match.groups?.src;
       widgetInstances[source] = {
         source,
-        transform: (widgetSource: string, widgetComponentName: string) => widgetSource.replaceAll(match[0], match[0].replace('Widget', widgetComponentName)),
+        transform: (widgetSource: string, widgetComponentName: string) => {
+          const signaturePrefix = `${widgetComponentName},{__bweMeta:{parentMeta:props.__bweMeta},`;
+          return widgetSource.replaceAll(match[0], match[0].replace(/Widget,\s*\{/, signaturePrefix));
+        },
       };
 
       return widgetInstances;

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -221,7 +221,9 @@ export function serializeNode({ builtinComponents, node, index, childWidgets, ca
 
   if (!type) {
     serializedElementType = 'div';
-  } else if (typeof type === 'function') {
+  }
+
+  if (typeof type === 'function') {
     const { name: component } = type;
     if (component === '_') {
       serializedElementType = 'div';
@@ -301,8 +303,7 @@ export function serializeNode({ builtinComponents, node, index, childWidgets, ca
           childWidgets,
           callbacks,
           parentId,
-        }) : c
-        ),
+        }) : c),
     },
     childWidgets,
   };

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -1,8 +1,9 @@
 export type Args = Array<Cloneable>;
 
-interface WebEngineMeta {
+export interface WebEngineMeta {
   componentId?: string;
   isProxy?: boolean;
+  parentMeta?: WebEngineMeta;
 }
 
 export type BuildRequestCallback = () => CallbackRequest;


### PR DESCRIPTION
This PR updates the Component state logic to allow trusted Component instances to parse their own IDs dynamically. This is done with the use of a `parentMeta` property on the `__bweMeta` object, analogous to prototype chains.