### PR TITLE
use regex from nomicon for account ID

### DIFF
--- a/apps/web/hooks/useWebEngine.ts
+++ b/apps/web/hooks/useWebEngine.ts
@@ -136,7 +136,7 @@ export function useWebEngine({ rootComponentPath, debugConfig }: UseWebEnginePar
   }, [processMessage]);
 
   useEffect(() => {
-    setIsValidRootComponentPath((/^[\w.]+\.near\/widget\/[\w.]+$/ig).test(rootComponentPath));
+    setIsValidRootComponentPath((/^((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/widget\/[\w.]+$/ig).test(rootComponentPath));
   }, [rootComponentPath]);
 
   useEffect(() => {

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -1,5 +1,5 @@
 export function parseChildComponentPaths(transpiledComponent: string) {
-  const componentRegex = /createElement\(Widget,\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>[\w.]+\.near\/widget\/[\w.]+))["|']/ig;
+  const componentRegex = /createElement\(Widget,\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/widget\/[\w.]+))["|']/ig;
   const matches = [...(transpiledComponent.matchAll(componentRegex))]
     .reduce((componentInstances, match) => {
       if (!match.groups?.src) {


### PR DESCRIPTION
Took this opportunity to update the path validation to use the full regex for NEAR accounts since I am deploying some test components to `bwe-demos.near` which was failing due to the hyphen