### PR TITLE
feat: sandboxed state

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
-const DEFAULT_ROOT_COMPONENT = 'andyh.near/widget/ComponentIdTestRoot';
+const DEFAULT_ROOT_COMPONENT = 'andyh.near/widget/LandingPage';
 
 export default function Web() {
   const router = useRouter();

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -59,7 +59,7 @@ export function buildComponentFunction({ componentPath, componentSource, isRoot 
 interface InitializeComponentStateParams {
   ComponentState: ComponentStateMap;
   componentInstanceId: string;
-  renderComponent?: () => void;
+  renderComponent?: ({ fromState }: { fromState: true }) => void;
 }
 
 function initializeComponentState({
@@ -84,7 +84,7 @@ function initializeComponentState({
     },
     update(newState: any, initialState = {}) {
       ComponentState.set(componentInstanceId, Object.assign(initialState, ComponentState.get(componentInstanceId), newState));
-      renderComponent?.();
+      renderComponent?.({ fromState: true });
     },
   };
 

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -30,6 +30,7 @@ export function buildComponentFunction({ componentPath, componentSource, isRoot 
         )({
           ComponentState,
           componentInstanceId: props?.__bweMeta?.componentId,
+          renderComponent,
         });
         ${componentSource}
       }
@@ -58,11 +59,13 @@ export function buildComponentFunction({ componentPath, componentSource, isRoot 
 interface InitializeComponentStateParams {
   ComponentState: ComponentStateMap;
   componentInstanceId: string;
+  renderComponent?: () => void;
 }
 
 function initializeComponentState({
   ComponentState,
   componentInstanceId,
+  renderComponent,
 }: InitializeComponentStateParams) {
   const state = new Proxy({}, {
     get(_, key) {
@@ -81,6 +84,7 @@ function initializeComponentState({
     },
     update(newState: any, initialState = {}) {
       ComponentState.set(componentInstanceId, Object.assign(initialState, ComponentState.get(componentInstanceId), newState));
+      renderComponent?.();
     },
   };
 

--- a/packages/container/src/events.ts
+++ b/packages/container/src/events.ts
@@ -168,6 +168,10 @@ export function buildEventHandler({
         let { args, method } = event.data;
         try {
           result = invokeCallbackFromEvent({ args, method });
+          if (typeof result?.then === 'function') {
+            result.catch((e: Error) => console.error('DOM event handler async callback failed', e));
+          }
+
           shouldRender = true; // TODO conditional re-render
         } catch (e: any) {
           error = e as Error;

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -172,30 +172,13 @@ export function deserializeProps({
 interface BuildComponentIdParams {
   instanceId: string | undefined;
   componentPath: string;
-  componentProps: object;
   parentComponentId: string;
 }
 
 export function serializeNode({ builtinComponents, node, childComponents, callbacks, parentId }: SerializeNodeParams): SerializedNode {
-  function buildComponentId({ instanceId, componentPath, componentProps, parentComponentId }: BuildComponentIdParams) {
-    if (instanceId !== undefined) {
-      return [componentPath, instanceId.toString(), parentComponentId].join('##');
-    }
-
-    const serializedProps = JSON.stringify(componentProps || {}).replace(/[{}\[\]'", ]/g, '');
-    const sampleInterval = Math.floor(serializedProps.length / 2048) || 1;
-    const sampledProps = serializedProps
-      .split('')
-      .reduce((sampled, c, i) => i % sampleInterval === 0 ? sampled + c : sampled, '');
-
-    const base64Props = btoa(
-      Array.from(
-        new TextEncoder().encode(sampledProps),
-        (byte) => String.fromCodePoint(byte)
-      ).join('')
-    );
-
-    return [componentPath, base64Props, parentComponentId].join('##');
+  function buildComponentId({ instanceId, componentPath, parentComponentId }: BuildComponentIdParams) {
+    // TODO warn on missing instanceId (<Widget>'s id prop) here?
+    return [componentPath, instanceId?.toString(), parentComponentId].join('##');
   }
 
   if (!node || typeof node !== 'object') {
@@ -240,7 +223,12 @@ export function serializeNode({ builtinComponents, node, childComponents, callba
       unifiedChildren = props.children || [];
     } else if (component === 'Widget') {
       const { id: instanceId, src, props: componentProps, isTrusted } = props;
-      const componentId = buildComponentId({ instanceId, componentPath: src, componentProps, parentComponentId: parentId });
+      const componentId = buildComponentId({
+        instanceId,
+        componentPath: src,
+        parentComponentId: parentId,
+      });
+
       try {
         childComponents.push({
           isTrusted: !!isTrusted,
@@ -265,7 +253,6 @@ export function serializeNode({ builtinComponents, node, childComponents, callba
       const componentId = buildComponentId({
         instanceId: props?.id,
         componentPath: props.src,
-        componentProps: props?.props,
         parentComponentId: parentId,
       });
 

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -1,18 +1,11 @@
 import type {
-  BuiltinProps,
   DeserializePropsParams,
-  FilesProps,
-  InfiniteScrollProps,
-  IpfsImageUploadProps,
-  MarkdownProps,
-  OverlayTriggerProps,
   Props,
   SerializeArgsParams,
   SerializeNodeParams,
   SerializePropsParams,
   SerializedArgs,
   SerializedNode,
-  TypeaheadProps,
 } from './types';
 
 export function encodeJsonString(value: string) {
@@ -232,7 +225,13 @@ export function serializeNode({ builtinComponents, node, childComponents, callba
       try {
         childComponents.push({
           isTrusted: !!isTrusted,
-          props: componentProps ? serializeProps({ props: componentProps, callbacks, builtinComponents, parentId, componentId }) : {},
+          props: componentProps ? serializeProps({
+            props: componentProps,
+            callbacks,
+            builtinComponents,
+            parentId,
+            componentId,
+          }) : {},
           source: src,
           componentId,
         });


### PR DESCRIPTION
This PR fixes rendering for sandboxed Components when `State.update()` is called. Historically the problem with this has been that Components may call `State.update()` at render time, triggering cascading renders until the call stack between `renderComponent()` and `State.update()` overflows.

I'm not convinced that supporting these `State.update()` invocations are a practical use case, and would prefer they ultimately be replaced with `useEffect` when available. My interim solution is to ignore re-render requests triggered by `State.update` when the Component has either:
- not finished rendering the initial render
- not re-rendered since the last update-triggered render

In my testing this pattern is still supported, but it's likely that this breaks assumptions on how this is expected to work. Again this pattern should be replaced with `useEffect`, but in the interim should not break the page.

In addition I've removed the fallback on `props`-derived Component IDs when the `id` prop is not provided on `Widget`. There is still no requirement that every `<Widget>` have an `id` specified, but not specifying `id` on multiple `<Widget>`s with the same `src` should be considered undefined behavior. E.g.

```jsx
// ex.near/widget/Parent
<Widget src="ex.near/widget/Child" />
```
✅ 

```jsx
// ex.near/widget/Parent
<Widget src="ex.near/widget/Child" />
<Widget id="lesser-child" src="ex.near/widget/Child" />
```
✅ 

```jsx
// ex.near/widget/Parent
<Widget src="ex.near/widget/Child" />
<Widget src="ex.near/widget/Child" />
```
❌ 

This fallback was always intended as a temporary measure and had been left around for debugging but is no longer necessary.