### PR TITLE
feat: explicit trust

### DIFF
--- a/apps/web/components/ComponentTree.tsx
+++ b/apps/web/components/ComponentTree.tsx
@@ -36,16 +36,22 @@ export default function ComponentTree({
           {isDebug && <h5>[hidden iframes]</h5>}
           {Object.entries(components)
             .filter(([, component]) => !!component?.componentSource)
-            .map(([componentId, { isTrusted, props, componentSource }]) => (
-              <div key={componentId} component-id={componentId}>
-                <SandboxedIframe
-                  id={getIframeId(componentId)}
-                  isTrusted={isTrusted}
-                  scriptSrc={componentSource}
-                  componentProps={props}
-                />
-              </div>
-            ))}
+            .map(
+              ([
+                componentId,
+                { isTrusted, props, componentSource, parentId },
+              ]) => (
+                <div key={componentId} component-id={componentId}>
+                  <SandboxedIframe
+                    id={getIframeId(componentId)}
+                    isTrusted={isTrusted}
+                    scriptSrc={componentSource}
+                    componentProps={props}
+                    parentContainerId={parentId}
+                  />
+                </div>
+              )
+            )}
         </div>
       </>
     </div>

--- a/apps/web/hooks/useWebEngine.ts
+++ b/apps/web/hooks/useWebEngine.ts
@@ -76,7 +76,6 @@ export function useWebEngine({
       compiler?.postMessage({
         action: 'execute',
         componentId,
-        isTrusted: component.isTrusted,
       });
     },
     [compiler, components, addComponent]
@@ -242,7 +241,6 @@ export function useWebEngine({
       compiler.postMessage({
         action: 'execute',
         componentId: rootComponentPath,
-        isTrusted: false,
       });
     }
   }, [

--- a/packages/application/src/container.ts
+++ b/packages/application/src/container.ts
@@ -11,9 +11,13 @@ function postMessageToIframe({
   message,
   targetOrigin,
 }: IframePostMessageParams): void {
-  (
-    document.getElementById(id) as HTMLIFrameElement
-  )?.contentWindow?.postMessage(message, targetOrigin);
+  const iframe = document.getElementById(id) as HTMLIFrameElement;
+  if (!iframe) {
+    console.error(`failed to send message to invalid iframe ${id}`, message);
+    return;
+  }
+
+  iframe.contentWindow?.postMessage(message, targetOrigin);
 }
 
 export function sendMessage({

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -116,7 +116,9 @@ export class ComponentCompiler {
     mapped,
   }: ParseComponentTreeParams) {
     // enumerate the set of Components referenced in the target Component
-    const childComponentPaths = parseChildComponentPaths(transpiledComponent);
+    const childComponentPaths = parseChildComponentPaths(
+      transpiledComponent
+    ).filter(({ isTrusted }) => isTrusted);
     let transformedComponent = transpiledComponent;
 
     // replace each child [Component] reference in the target Component source

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -13,7 +13,6 @@ export type ComponentCompilerRequest =
 interface CompilerExecuteAction {
   action: 'execute';
   componentId: string;
-  isTrusted: boolean;
 }
 
 interface CompilerInitAction {
@@ -168,7 +167,7 @@ export class ComponentCompiler {
     return mapped;
   }
 
-  async compileComponent({ componentId, isTrusted }: CompilerExecuteAction) {
+  async compileComponent({ componentId }: CompilerExecuteAction) {
     if (this.localFetchUrl && !this.hasFetchedLocal) {
       try {
         await this.fetchLocalComponents();
@@ -198,21 +197,19 @@ export class ComponentCompiler {
     });
 
     let componentSource = transpiledComponent;
-    if (isTrusted) {
-      // recursively parse the Component tree for child Components
-      const transformedComponents = await this.parseComponentTree({
-        componentPath,
-        transpiledComponent,
-        mapped: {},
-      });
+    // recursively parse the Component tree for child Components
+    const transformedComponents = await this.parseComponentTree({
+      componentPath,
+      transpiledComponent,
+      mapped: {},
+    });
 
-      const [rootComponent, ...childComponents] = Object.values(
-        transformedComponents
-      ).map(({ transpiled }) => transpiled);
-      const aggregatedSourceLines = rootComponent.split('\n');
-      aggregatedSourceLines.splice(1, 0, childComponents.join('\n\n'));
-      componentSource = aggregatedSourceLines.join('\n');
-    }
+    const [rootComponent, ...childComponents] = Object.values(
+      transformedComponents
+    ).map(({ transpiled }) => transpiled);
+    const aggregatedSourceLines = rootComponent.split('\n');
+    aggregatedSourceLines.splice(1, 0, childComponents.join('\n\n'));
+    componentSource = aggregatedSourceLines.join('\n');
 
     this.sendWorkerMessage({
       componentId,

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -65,7 +65,7 @@ export function buildComponentFunction({
 interface InitializeComponentStateParams {
   ComponentState: ComponentStateMap;
   componentInstanceId: string;
-  renderComponent?: ({ fromState }: { fromState: true }) => void;
+  renderComponent?: ({ stateUpdate }: { stateUpdate: string }) => void;
 }
 
 function initializeComponentState({
@@ -100,7 +100,7 @@ function initializeComponentState({
           newState
         )
       );
-      renderComponent?.({ fromState: true });
+      renderComponent?.({ stateUpdate: JSON.stringify(newState) });
     },
   };
 

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -55,6 +55,7 @@ export function buildComponentFunction({
           __bweInlineComponentProps.id,
           __bweMeta?.parentMeta?.componentId,
         ].filter((c) => c !== undefined).join('##'),
+        renderComponent,
       });
       ${componentSource}
     }

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -44,7 +44,8 @@ export function buildComponentFunction({
   return `
     /************************* ${componentPath} *************************/
     function ${functionName}(__bweInlineComponentProps) {
-      const { props } = __bweInlineComponentProps;
+      const { __bweMeta, props: __componentProps } = __bweInlineComponentProps;
+      const props = Object.assign({ __bweMeta }, __componentProps); 
       const { state, State } = (
         ${initializeComponentState.toString()}
       )({
@@ -52,7 +53,7 @@ export function buildComponentFunction({
         componentInstanceId: [
           '${componentPath}',
           __bweInlineComponentProps.id,
-          __bweInlineComponentProps.__bweMeta?.parentMeta?.componentId,
+          __bweMeta?.parentMeta?.componentId,
         ].filter((c) => c !== undefined).join('##'),
       });
       ${componentSource}

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -1,33 +1,48 @@
-export function parseChildComponentPaths(transpiledComponent: string) {
+function parseWidgetRenders(transpiledComponent: string) {
+  const functionOffset = 'createElement'.length;
   const componentRegex =
     /createElement\(Widget,\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/widget\/[\w.]+))["|']/gi;
-  const matches = [...transpiledComponent.matchAll(componentRegex)].reduce(
-    (componentInstances, match) => {
-      if (!match.groups?.src) {
-        return componentInstances;
+  return [...transpiledComponent.matchAll(componentRegex)].map((match) => {
+    const openParenIndex = match.index! + functionOffset;
+    let parenCount = 1;
+    let idx = openParenIndex + 1;
+    while (parenCount > 0) {
+      const char = transpiledComponent[idx++];
+      if (char === '(') {
+        parenCount++;
+      } else if (char === ')') {
+        parenCount--;
       }
+    }
 
-      const source = match.groups?.src;
-      componentInstances[source] = {
+    return {
+      expression: transpiledComponent.substring(
+        openParenIndex - functionOffset,
+        idx
+      ),
+      source: match.groups?.src || '',
+    };
+  });
+}
+
+export function parseChildComponentPaths(transpiledComponent: string) {
+  return parseWidgetRenders(transpiledComponent).map(
+    ({ expression, source }) => {
+      const [trustMatch] = [
+        ...expression.matchAll(/isTrusted(?:\s*:\s*(true|false))/gi),
+      ];
+
+      return {
         source,
+        isTrusted: trustMatch?.[1] === 'true',
         transform: (componentSource: string, componentName: string) => {
           const signaturePrefix = `${componentName},{__bweMeta:{parentMeta:props.__bweMeta},`;
           return componentSource.replaceAll(
-            match[0],
-            match[0].replace(/Widget,\s*\{/, signaturePrefix)
+            expression,
+            expression.replace(/Widget,\s*\{/, signaturePrefix)
           );
         },
       };
-
-      return componentInstances;
-    },
-    {} as {
-      [key: string]: {
-        source: string;
-        transform: (s: string, n: string) => string;
-      };
     }
   );
-
-  return Object.values(matches);
 }

--- a/packages/container/src/callbacks.ts
+++ b/packages/container/src/callbacks.ts
@@ -75,6 +75,7 @@ export function invokeComponentCallback({
           method: componentMethod,
           requestId,
           serializeArgs,
+          // TODO must specify a real value here
           targetId: componentMethod.split('::').slice(1).join('::'),
           componentId,
         });

--- a/packages/container/src/events.ts
+++ b/packages/container/src/events.ts
@@ -26,9 +26,11 @@ export function buildEventHandler({
   buildRequest,
   builtinComponents,
   callbacks,
+  componentId,
   deserializeProps,
   invokeCallback,
   invokeComponentCallback,
+  parentContainerId,
   postCallbackInvocationMessage,
   postCallbackResponseMessage,
   renderDom,
@@ -37,7 +39,6 @@ export function buildEventHandler({
   serializeArgs,
   serializeNode,
   setProps,
-  componentId,
 }: ProcessEventParams): Function {
   return function processEvent(event: PostMessageEvent) {
     let error: any = null;
@@ -51,6 +52,11 @@ export function buildEventHandler({
       args: SerializedArgs;
       method: string;
     }) {
+      if (!parentContainerId) {
+        console.error(`no parent container for ${componentId}`);
+        return;
+      }
+
       return invokeComponentCallback({
         args,
         buildRequest,
@@ -61,6 +67,7 @@ export function buildEventHandler({
         postCallbackInvocationMessage,
         requests,
         serializeArgs,
+        targetId: parentContainerId,
       });
     }
 
@@ -195,10 +202,11 @@ export function buildEventHandler({
           deserializeProps({
             buildRequest,
             callbacks,
+            componentId,
+            parentContainerId,
             postCallbackInvocationMessage,
             props: event.data.props,
             requests,
-            componentId,
           })
         );
         break;

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -17,11 +17,12 @@ export type CallbackMap = { [key: string]: Function };
 export type DeserializePropsCallback = (props: DeserializePropsParams) => any;
 export interface DeserializePropsParams {
   buildRequest: BuildRequestCallback;
-  props: SerializedProps;
   callbacks: CallbackMap;
+  componentId: string;
+  parentContainerId: string | null;
+  props: SerializedProps;
   postCallbackInvocationMessage: PostMessageComponentInvocationCallback;
   requests: { [key: string]: CallbackRequest };
-  componentId: string;
 }
 
 export type EventArgs = { event: any };
@@ -65,6 +66,7 @@ export interface InvokeComponentCallbackParams {
   postCallbackInvocationMessage: PostMessageComponentInvocationCallback;
   requests: { [key: string]: CallbackRequest };
   serializeArgs: SerializeArgsCallback;
+  targetId: string;
 }
 
 export interface KeyValuePair {
@@ -161,9 +163,11 @@ export interface ProcessEventParams {
   buildRequest: BuildRequestCallback;
   builtinComponents: BuiltinComponents;
   callbacks: CallbackMap;
+  componentId: string;
   deserializeProps: DeserializePropsCallback;
   invokeCallback: (args: InvokeCallbackParams) => any;
   invokeComponentCallback: (args: InvokeComponentCallbackParams) => any;
+  parentContainerId: string | null;
   postCallbackInvocationMessage: PostMessageComponentInvocationCallback;
   postCallbackResponseMessage: PostMessageComponentResponseCallback;
   props: any;
@@ -173,7 +177,6 @@ export interface ProcessEventParams {
   serializeArgs: SerializeArgsCallback;
   serializeNode: SerializeNodeCallback;
   setProps: (props: object) => boolean;
-  componentId: string;
 }
 
 export interface Props extends KeyValuePair {

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -213,21 +213,26 @@ function buildSandboxedComponent({
             }
           }
       
-          let renderCount = 0;
-          let lastStateRender = 0;
+          const stateUpdates = new Map();
 
-          function renderComponent({ fromState } = { fromState: false }) {
+          function renderComponent({ stateUpdate } = {}) {
             try {
               // TODO remove this kludge-y stopgap preventing State.update() calls on render from triggering cascading renders.
               //  This likely has unintended consequences for Components calling State.update() at render time, but that should
               //  be considered an antipattern to be replaced by a [useEffect] implementation.
-              if (fromState && (renderCount === 0 || lastStateRender === renderCount - 1)) {
-                lastStateRender = ++renderCount;
-                return;
+              if (stateUpdate) {
+                if (!stateUpdates.has(stateUpdate)) {
+                  stateUpdates.set(stateUpdate, []);
+                }
+
+                const updates = stateUpdates.get(stateUpdate);
+                stateUpdates.set(stateUpdate, [...updates, (new Date()).valueOf()]);
+                if (updates.length > 5) {
+                  return;
+                }
               }
 
               render(ComponentWrapper(), document.getElementById('${id}'));
-              renderCount++;
             } catch (e) {
               console.error(e, { componentId: '${id}' });
             }

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -25,6 +25,7 @@ function buildSandboxedComponent({
   isTrusted,
   scriptSrc,
   componentProps,
+  parentContainerId,
 }: SandboxedIframeProps) {
   const componentPath = id.split('::')[0];
   let jsonComponentProps = '{}';
@@ -151,12 +152,13 @@ function buildSandboxedComponent({
           let props = buildSafeProxy(deserializeProps({
             buildRequest,
             callbacks,
+            componentId: '${id}',
+            parentContainerId: '${parentContainerId}',
             postCallbackInvocationMessage,
             props: JSON.parse('${jsonComponentProps
               .replace(/'/g, "\\'")
               .replace(/\\"/g, '\\\\"')}'),
             requests,
-            componentId: '${id}',
           }));
 
           function asyncFetch(url, options) {
@@ -267,6 +269,7 @@ function buildSandboxedComponent({
             deserializeProps,
             invokeCallback,
             invokeComponentCallback,
+            parentContainerId: '${parentContainerId}',
             postCallbackInvocationMessage,
             postCallbackResponseMessage,
             renderDom: (node) => preactify(node),
@@ -297,6 +300,7 @@ interface SandboxedIframeProps {
   isTrusted: boolean;
   scriptSrc: string;
   componentProps?: any;
+  parentContainerId: string | null;
 }
 
 export function SandboxedIframe({
@@ -304,6 +308,7 @@ export function SandboxedIframe({
   isTrusted,
   scriptSrc,
   componentProps,
+  parentContainerId,
 }: SandboxedIframeProps) {
   return (
     <iframe
@@ -325,6 +330,7 @@ export function SandboxedIframe({
         isTrusted,
         scriptSrc,
         componentProps,
+        parentContainerId,
       })}
       title="code-container"
       width={0}


### PR DESCRIPTION
This PR rounds out the trusted loading implementation by inlining trusted Components within the parent container and only renders its descendants as trusted if they have explicitly opted into it.

I've also updated the workaround for dealing with `State.update()` calls on render to ignore `State`-triggered re-renders with the same value. This will fail for values that always change (e.g. `State.update({ t: Date.now() })`) but should suffice until hooks are implemented. Upside is that state updates now re-render automatically.

Closes #73