### PR TITLE
feat: replace `isTrusted`

### DIFF
--- a/apps/web/components/ComponentTree.tsx
+++ b/apps/web/components/ComponentTree.tsx
@@ -37,14 +37,11 @@ export default function ComponentTree({
           {Object.entries(components)
             .filter(([, component]) => !!component?.componentSource)
             .map(
-              ([
-                componentId,
-                { isTrusted, props, componentSource, parentId },
-              ]) => (
+              ([componentId, { trust, props, componentSource, parentId }]) => (
                 <div key={componentId} component-id={componentId}>
                   <SandboxedIframe
                     id={getIframeId(componentId)}
-                    isTrusted={isTrusted}
+                    trust={trust}
                     scriptSrc={componentSource}
                     componentProps={props}
                     parentContainerId={parentId}

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -13,6 +13,7 @@
     "@bos-web-engine/iframe": "workspace:*"
   },
   "devDependencies": {
+    "@bos-web-engine/common": "workspace:*",
     "@bos-web-engine/container": "workspace:*",
     "@types/node": "^17.0.12",
     "@types/react": "^18.0.17",

--- a/packages/application/src/handlers.ts
+++ b/packages/application/src/handlers.ts
@@ -1,3 +1,4 @@
+import type { ComponentTrust } from '@bos-web-engine/common';
 import React from 'react';
 
 import { sendMessage } from './container';
@@ -57,7 +58,7 @@ interface ChildComponent {
   componentId: string;
   props: any;
   source: string;
-  isTrusted: boolean;
+  trust: ComponentTrust;
 }
 
 export function onRender({
@@ -115,7 +116,7 @@ export function onRender({
       componentId: childComponentId,
       props: componentProps,
       source,
-      isTrusted,
+      trust,
     }: ChildComponent) => {
       /*
       a new Component is being rendered by a parent Component, either:
@@ -127,7 +128,7 @@ export function onRender({
         loadComponent({
           componentId: childComponentId,
           componentPath: source,
-          isTrusted,
+          trust,
           parentId: componentId,
           props: componentProps,
           renderCount: 0,

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -1,3 +1,4 @@
+import { ComponentTrust } from '@bos-web-engine/common';
 import type {
   ComponentCallbackInvocation,
   ComponentCallbackResponse,
@@ -19,10 +20,10 @@ export interface CallbackResponseHandlerParams {
 export interface ComponentInstance {
   componentId: string;
   componentPath: string;
-  isTrusted: boolean;
   parentId: string;
   props: any;
   renderCount: number;
+  trust: ComponentTrust;
 }
 
 export interface ComponentMetrics {

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['custom'],
+};

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@bos-web-engine/common",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "tsc -p ./tsconfig.json",
+    "dev": "tsc -w -p ./tsconfig.json",
+    "lint": "eslint ./src/**/*.ts*",
+    "lint:fix": "eslint . --fix"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.12",
+    "@types/react": "^18.2.25",
+    "eslint": "^7.32.0",
+    "eslint-config-custom": "workspace:*",
+    "react": "^18.2.0",
+    "tsconfig": "workspace:*",
+    "typescript": "^4.5.2"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,4 +1,4 @@
-enum TrustMode {
+export enum TrustMode {
   Sandboxed = 'sandboxed',
   Trusted = 'trusted',
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,0 +1,8 @@
+enum TrustMode {
+  Sandboxed = 'sandboxed',
+  Trusted = 'trusted',
+}
+
+export interface ComponentTrust {
+  mode: TrustMode;
+}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,6 +1,7 @@
 export enum TrustMode {
   Sandboxed = 'sandboxed',
   Trusted = 'trusted',
+  TrustAuthor = 'trusted-author',
 }
 
 export interface ComponentTrust {

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "tsconfig/react-library.json",
+  "include": ["src"],
+  "exclude": ["lib", "dist", "build", "node_modules"],
+  "compilerOptions": {
+    "outDir": "./lib",
+    "lib": [
+      "dom"
+    ]
+  },
+  "watchOptions": {
+    // Use native file system events for files and directories
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
+    // Poll files for updates more frequently
+    // when they're updated a lot.
+    "fallbackPolling": "dynamicPriority",
+    // Don't coalesce watch notification
+    "synchronousWatchDirectory": true,
+    // Finally, two additional settings for reducing the amount of possible
+    // files to track  work from these directories
+    "excludeDirectories": ["**/node_modules", "_build"]
+  }
+}

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@babel/standalone": "^7.22.14",
+    "@bos-web-engine/common": "workspace:*",
     "@bos-web-engine/container": "workspace:*",
     "@near-js/providers": "^0.0.7"
   },

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -1,8 +1,10 @@
+import { TrustMode } from '@bos-web-engine/common';
+
 import {
   buildComponentFunction,
   buildComponentFunctionName,
 } from './component';
-import { parseChildComponentPaths } from './parser';
+import { parseChildComponents, ParsedChildComponent } from './parser';
 import { fetchComponentSources } from './source';
 import { transpileSource } from './transpile';
 
@@ -42,6 +44,15 @@ interface ParseComponentTreeParams {
   mapped: { [key: string]: { transpiled: string } };
   transpiledComponent: string;
   componentPath: string;
+  isComponentPathTrusted?: (path: string) => boolean;
+  trustedRoot?: TrustedRoot;
+}
+
+interface TrustedRoot {
+  rootPath: string;
+  trustMode: string;
+  /* predicates for determining trust under a trusted root */
+  matchesRootAuthor: (path: string) => boolean;
 }
 
 export class ComponentCompiler {
@@ -80,14 +91,14 @@ export class ComponentCompiler {
       });
     }
 
-    return componentPaths.reduce((sources, componentPath) => {
+    const componentSources = new Map<string, Promise<string>>();
+    componentPaths.forEach((componentPath) => {
       const componentSource = this.bosSourceCache.get(componentPath);
       if (componentSource) {
-        sources.set(componentPath, componentSource);
+        componentSources.set(componentPath, componentSource);
       }
-
-      return sources;
-    }, new Map<string, Promise<string>>());
+    });
+    return componentSources;
   }
 
   getTranspiledComponentSource({
@@ -109,69 +120,119 @@ export class ComponentCompiler {
     return this.compiledSourceCache.get(cacheKey)!;
   }
 
+  static isChildComponentTrusted(
+    { trustMode, path }: ParsedChildComponent,
+    isComponentPathTrusted?: (p: string) => boolean
+  ) {
+    if (
+      trustMode === TrustMode.Trusted ||
+      trustMode === TrustMode.TrustAuthor
+    ) {
+      return true;
+    }
+
+    if (trustMode === TrustMode.Sandboxed) {
+      return false;
+    }
+
+    // if the Component is not explicitly trusted or sandboxed, use the parent's
+    // predicate to determine whether the Component should be trusted
+    if (isComponentPathTrusted) {
+      return isComponentPathTrusted(path);
+    }
+
+    return false;
+  }
+
   async parseComponentTree({
     componentPath,
     transpiledComponent,
     mapped,
+    isComponentPathTrusted,
+    trustedRoot,
   }: ParseComponentTreeParams) {
     // enumerate the set of Components referenced in the target Component
-    const childComponentPaths = parseChildComponentPaths(transpiledComponent);
-    const trustedPaths = childComponentPaths.filter(({ trustMode }) => {
-      if (trustMode === TrustMode.Trusted) {
-        return true;
+    const childComponents = parseChildComponents(transpiledComponent);
+
+    // each child Component being rendered as a new trusted root (i.e. trust mode `trusted-author`)
+    // will track inclusion criteria when evaluating trust for their children in turn
+    const buildTrustedRootKey = ({ index, path }: ParsedChildComponent) =>
+      `${index}:${path}`;
+    const trustedRoots = childComponents.reduce((trusted, childComponent) => {
+      const { trustMode } = childComponent;
+
+      // trust Components with the same author as the trusted root Component
+      if (trustMode === TrustMode.TrustAuthor) {
+        const rootComponentAuthor = componentPath.split('/')[0];
+        trusted.set(buildTrustedRootKey(childComponent), {
+          rootPath: componentPath,
+          trustMode,
+          matchesRootAuthor: (path: string) =>
+            path.split('/')[0] === rootComponentAuthor,
+        });
       }
 
-      if (trustMode === TrustMode.Sandboxed) {
-        return false;
-      }
+      return trusted;
+    }, new Map<string, TrustedRoot>());
 
-      return false;
-    });
-
-    let transformedComponent = transpiledComponent;
-
-    // replace each child [Component] reference in the target Component source
-    // with the generated name of the inlined Component function definition
-    trustedPaths.forEach(({ source, transform }) => {
-      transformedComponent = transform(
-        transformedComponent,
-        buildComponentFunctionName(source)
-      );
-    });
+    const trustedChildComponents = childComponents.filter((child) =>
+      ComponentCompiler.isChildComponentTrusted(child, isComponentPathTrusted)
+    );
 
     // add the transformed source to the returned Component tree
     mapped[componentPath] = {
-      transpiled: transformedComponent,
+      // replace each child [Component] reference in the target Component source
+      // with the generated name of the inlined Component function definition
+      transpiled: trustedChildComponents.reduce(
+        (transformed, { path, transform }) =>
+          transform(transformed, buildComponentFunctionName(path)),
+        transpiledComponent
+      ),
     };
 
     // fetch the set of child Component sources not already added to the tree
     const childComponentSources = this.getComponentSources(
-      trustedPaths
-        .map(({ source }) => source)
-        .filter((source) => !(source in mapped))
+      trustedChildComponents
+        .map(({ path }) => path)
+        .filter((path) => !(path in mapped))
     );
 
     // transpile the set of new child Components and recursively parse their Component subtrees
     await Promise.all(
-      [...childComponentSources.entries()].map(
-        async ([childPath, componentSource]) => {
-          const transpiledChild = this.getTranspiledComponentSource({
-            componentPath: childPath,
+      trustedChildComponents.map(async (childComponent) => {
+        const { path } = childComponent;
+        let transpiledChild = mapped[path]?.transpiled;
+        if (!transpiledChild) {
+          transpiledChild = this.getTranspiledComponentSource({
+            componentPath: path,
             componentSource: buildComponentFunction({
-              componentPath: childPath,
-              componentSource: await componentSource,
+              componentPath: path,
+              componentSource: (await childComponentSources.get(path))!,
               isRoot: false,
             }),
             isRoot: false,
           });
-
-          await this.parseComponentTree({
-            componentPath: childPath,
-            transpiledComponent: transpiledChild,
-            mapped,
-          });
         }
-      )
+
+        const childTrustedRoot =
+          trustedRoots.get(buildTrustedRootKey(childComponent)) || trustedRoot;
+
+        await this.parseComponentTree({
+          componentPath: path,
+          transpiledComponent: transpiledChild,
+          mapped,
+          trustedRoot: childTrustedRoot,
+          isComponentPathTrusted:
+            trustedRoot?.trustMode === TrustMode.Sandboxed
+              ? undefined
+              : () => {
+                  if (childTrustedRoot?.trustMode === TrustMode.TrustAuthor) {
+                    return !!childTrustedRoot?.matchesRootAuthor(path);
+                  }
+                  return false;
+                },
+        });
+      })
     );
 
     return mapped;

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -29,12 +29,14 @@ export function parseChildComponentPaths(transpiledComponent: string) {
   return parseWidgetRenders(transpiledComponent).map(
     ({ expression, source }) => {
       const [trustMatch] = [
-        ...expression.matchAll(/isTrusted(?:\s*:\s*(true|false))/gi),
+        ...expression.matchAll(
+          /trust(?:\s*:\s*{(?:[\w\W])*?mode\s*:\s*['"](trusted|sandboxed))/gi
+        ),
       ];
 
       return {
         source,
-        isTrusted: trustMatch?.[1] === 'true',
+        isTrusted: trustMatch?.[1] === 'trusted',
         transform: (componentSource: string, componentName: string) => {
           const signaturePrefix = `${componentName},{__bweMeta:{parentMeta:props.__bweMeta},`;
           return componentSource.replaceAll(

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -36,7 +36,7 @@ export function parseChildComponentPaths(transpiledComponent: string) {
 
       return {
         source,
-        isTrusted: trustMatch?.[1] === 'trusted',
+        trustMode: trustMatch?.[1],
         transform: (componentSource: string, componentName: string) => {
           const signaturePrefix = `${componentName},{__bweMeta:{parentMeta:props.__bweMeta},`;
           return componentSource.replaceAll(

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -11,11 +11,8 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.12",
-    "@types/react": "^18.0.17",
-    "@types/react-dom": "^18.0.6",
     "eslint": "^7.32.0",
     "eslint-config-custom": "workspace:*",
-    "react": "^18.2.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   },

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
+    "@bos-web-engine/common": "workspace:*",
     "@types/node": "^17.0.12",
     "eslint": "^7.32.0",
     "eslint-config-custom": "workspace:*",

--- a/packages/container/src/messaging.ts
+++ b/packages/container/src/messaging.ts
@@ -71,13 +71,13 @@ export function postCallbackResponseMessage({
 
 export function postComponentRenderMessage({
   childComponents,
-  isTrusted,
+  trust,
   node,
   componentId,
 }: PostMessageComponentRenderParams): void {
   postMessage<ComponentRender>({
     childComponents,
-    isTrusted,
+    trust,
     node,
     type: 'component.render',
     componentId,

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -253,7 +253,7 @@ export function serializeNode({
       }));
       unifiedChildren = props.children || [];
     } else if (component === 'Widget') {
-      const { id: instanceId, src, props: componentProps, isTrusted } = props;
+      const { id: instanceId, src, props: componentProps, trust } = props;
       const componentId = buildComponentId({
         instanceId,
         componentPath: src,
@@ -262,7 +262,7 @@ export function serializeNode({
 
       try {
         childComponents.push({
-          isTrusted: !!isTrusted,
+          trust,
           props: componentProps
             ? serializeProps({
                 props: componentProps,

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -1,3 +1,5 @@
+import type { ComponentTrust } from '@bos-web-engine/common';
+
 export interface WebEngineMeta {
   componentId?: string;
   isProxy?: boolean;
@@ -141,15 +143,15 @@ export interface PostMessageComponentCallbackResponseParams {
 
 export interface ComponentRender extends PostMessageParams {
   childComponents: ComponentChildMetadata[];
-  isTrusted: boolean;
   node: SerializedNode;
+  trust: ComponentTrust;
   type: ComponentRenderType;
   componentId: string;
 }
 export interface PostMessageComponentRenderParams {
   childComponents: ComponentChildMetadata[];
-  isTrusted: boolean;
   node: SerializedNode;
+  trust: ComponentTrust;
   componentId: string;
 }
 
@@ -239,9 +241,9 @@ export interface Node {
 
 interface ComponentChildMetadata {
   componentId: string;
-  isTrusted: boolean;
   props: Props;
   source: string;
+  trust: ComponentTrust;
 }
 
 export interface SerializeNodeParams {

--- a/packages/iframe/package.json
+++ b/packages/iframe/package.json
@@ -13,6 +13,7 @@
     "@bos-web-engine/container": "workspace:*"
   },
   "devDependencies": {
+    "@bos-web-engine/common": "workspace:*",
     "@types/node": "^17.0.12",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -1,3 +1,4 @@
+import type { ComponentTrust } from '@bos-web-engine/common';
 import {
   buildUseComponentCallback,
   initNear,
@@ -22,7 +23,7 @@ import {
 
 function buildSandboxedComponent({
   id,
-  isTrusted,
+  trust,
   scriptSrc,
   componentProps,
   parentContainerId,
@@ -108,7 +109,7 @@ function buildSandboxedComponent({
             try {
               postComponentRenderMessage({
                 childComponents,
-                isTrusted: ${isTrusted},
+                trust: ${JSON.stringify(trust)},
                 node: serialized,
                 componentId: componentId,
               });
@@ -302,7 +303,7 @@ function buildSandboxedComponent({
 
 interface SandboxedIframeProps {
   id: string;
-  isTrusted: boolean;
+  trust: ComponentTrust;
   scriptSrc: string;
   componentProps?: any;
   parentContainerId: string | null;
@@ -310,7 +311,7 @@ interface SandboxedIframeProps {
 
 export function SandboxedIframe({
   id,
-  isTrusted,
+  trust,
   scriptSrc,
   componentProps,
   parentContainerId,
@@ -332,7 +333,7 @@ export function SandboxedIframe({
       sandbox="allow-scripts"
       srcDoc={buildSandboxedComponent({
         id: id.replace('iframe-', ''),
-        isTrusted,
+        trust,
         scriptSrc,
         componentProps,
         parentContainerId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,7 @@ importers:
   packages/compiler:
     specifiers:
       '@babel/standalone': ^7.22.14
+      '@bos-web-engine/common': workspace:*
       '@bos-web-engine/container': workspace:*
       '@near-js/providers': ^0.0.7
       '@near-js/types': ^0.0.4
@@ -122,6 +123,7 @@ importers:
       typescript: ^4.5.2
     dependencies:
       '@babel/standalone': 7.22.14
+      '@bos-web-engine/common': link:../common
       '@bos-web-engine/container': link:../container
       '@near-js/providers': 0.0.7
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
       next: 13.4.13
       prettier: 3.0.3
       rimraf: 5.0.1
-      turbo: 1.10.14
+      turbo: 1.10.15
 
   apps/web:
     specifiers:
@@ -116,20 +116,14 @@ importers:
   packages/container:
     specifiers:
       '@types/node': ^17.0.12
-      '@types/react': ^18.0.17
-      '@types/react-dom': ^18.0.6
       eslint: ^7.32.0
       eslint-config-custom: workspace:*
-      react: ^18.2.0
       tsconfig: workspace:*
       typescript: ^4.5.2
     devDependencies:
       '@types/node': 17.0.45
-      '@types/react': 18.2.20
-      '@types/react-dom': 18.2.7
       eslint: 7.32.0
       eslint-config-custom: link:../eslint-config-custom
-      react: 18.2.0
       tsconfig: link:../tsconfig
       typescript: 4.9.5
 
@@ -144,7 +138,7 @@ importers:
     dependencies:
       eslint: 7.32.0
       eslint-config-next: 13.0.0_jofidmxrjzhj7l6vknpw5ecvfe
-      eslint-config-turbo: 1.10.14_eslint@7.32.0
+      eslint-config-turbo: 1.10.15_eslint@7.32.0
       eslint-plugin-import: 2.28.0_eslint@7.32.0
       eslint-plugin-react: 7.31.8_eslint@7.32.0
     devDependencies:
@@ -2573,13 +2567,13 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-config-turbo/1.10.14_eslint@7.32.0:
-    resolution: {integrity: sha512-ZeB+IcuFXy1OICkLuAplVa0euoYbhK+bMEQd0nH9+Lns18lgZRm33mVz/iSoH9VdUzl/1ZmFmoK+RpZc+8R80A==}
+  /eslint-config-turbo/1.10.15_eslint@7.32.0:
+    resolution: {integrity: sha512-76mpx2x818JZE26euen14utYcFDxOahZ9NaWA+6Xa4pY2ezVKVschuOxS96EQz3o3ZRSmcgBOapw/gHbN+EKxQ==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
       eslint: 7.32.0
-      eslint-plugin-turbo: 1.10.14_eslint@7.32.0
+      eslint-plugin-turbo: 1.10.15_eslint@7.32.0
     dev: false
 
   /eslint-import-resolver-node/0.3.9:
@@ -2796,8 +2790,8 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: false
 
-  /eslint-plugin-turbo/1.10.14_eslint@7.32.0:
-    resolution: {integrity: sha512-sBdBDnYr9AjT1g4lR3PBkZDonTrMnR4TvuGv5W0OiF7z9az1rI68yj2UHJZvjkwwcGu5mazWA1AfB0oaagpmfg==}
+  /eslint-plugin-turbo/1.10.15_eslint@7.32.0:
+    resolution: {integrity: sha512-Tv4QSKV/U56qGcTqS/UgOvb9HcKFmWOQcVh3HEaj7of94lfaENgfrtK48E2CckQf7amhKs1i+imhCsNCKjkQyA==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
@@ -4280,64 +4274,64 @@ packages:
       typescript: 4.9.5
     dev: false
 
-  /turbo-darwin-64/1.10.14:
-    resolution: {integrity: sha512-I8RtFk1b9UILAExPdG/XRgGQz95nmXPE7OiGb6ytjtNIR5/UZBS/xVX/7HYpCdmfriKdVwBKhalCoV4oDvAGEg==}
+  /turbo-darwin-64/1.10.15:
+    resolution: {integrity: sha512-Sik5uogjkRTe1XVP9TC2GryEMOJCaKE2pM/O9uLn4koQDnWKGcLQv+mDU+H+9DXvKLnJnKCD18OVRkwK5tdpoA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.10.14:
-    resolution: {integrity: sha512-KAdUWryJi/XX7OD0alOuOa0aJ5TLyd4DNIYkHPHYcM6/d7YAovYvxRNwmx9iv6Vx6IkzTnLeTiUB8zy69QkG9Q==}
+  /turbo-darwin-arm64/1.10.15:
+    resolution: {integrity: sha512-xwqyFDYUcl2xwXyGPmHkmgnNm4Cy0oNzMpMOBGRr5x64SErS7QQLR4VHb0ubiR+VAb8M+ECPklU6vD1Gm+wekg==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.10.14:
-    resolution: {integrity: sha512-BOBzoREC2u4Vgpap/WDxM6wETVqVMRcM8OZw4hWzqCj2bqbQ6L0wxs1LCLWVrghQf93JBQtIGAdFFLyCSBXjWQ==}
+  /turbo-linux-64/1.10.15:
+    resolution: {integrity: sha512-dM07SiO3RMAJ09Z+uB2LNUSkPp3I1IMF8goH5eLj+d8Kkwoxd/+qbUZOj9RvInyxU/IhlnO9w3PGd3Hp14m/nA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.10.14:
-    resolution: {integrity: sha512-D8T6XxoTdN5D4V5qE2VZG+/lbZX/89BkAEHzXcsSUTRjrwfMepT3d2z8aT6hxv4yu8EDdooZq/2Bn/vjMI32xw==}
+  /turbo-linux-arm64/1.10.15:
+    resolution: {integrity: sha512-MkzKLkKYKyrz4lwfjNXH8aTny5+Hmiu4SFBZbx+5C0vOlyp6fV5jZANDBvLXWiDDL4DSEAuCEK/2cmN6FVH1ow==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.10.14:
-    resolution: {integrity: sha512-zKNS3c1w4i6432N0cexZ20r/aIhV62g69opUn82FLVs/zk3Ie0GVkSB6h0rqIvMalCp7enIR87LkPSDGz9K4UA==}
+  /turbo-windows-64/1.10.15:
+    resolution: {integrity: sha512-3TdVU+WEH9ThvQGwV3ieX/XHebtYNHv9HARHauPwmVj3kakoALkpGxLclkHFBLdLKkqDvmHmXtcsfs6cXXRHJg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.10.14:
-    resolution: {integrity: sha512-rkBwrTPTxNSOUF7of8eVvvM+BkfkhA2OvpHM94if8tVsU+khrjglilp8MTVPHlyS9byfemPAmFN90oRIPB05BA==}
+  /turbo-windows-arm64/1.10.15:
+    resolution: {integrity: sha512-l+7UOBCbfadvPMYsX08hyLD+UIoAkg6ojfH+E8aud3gcA1padpjCJTh9gMpm3QdMbKwZteT5uUM+wyi6Rbbyww==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.10.14:
-    resolution: {integrity: sha512-hr9wDNYcsee+vLkCDIm8qTtwhJ6+UAMJc3nIY6+PNgUTtXcQgHxCq8BGoL7gbABvNWv76CNbK5qL4Lp9G3ZYRA==}
+  /turbo/1.10.15:
+    resolution: {integrity: sha512-mKKkqsuDAQy1wCCIjCdG+jOCwUflhckDMSRoeBPcIL/CnCl7c5yRDFe7SyaXloUUkt4tUR0rvNIhVCcT7YeQpg==}
     hasBin: true
     optionalDependencies:
-      turbo-darwin-64: 1.10.14
-      turbo-darwin-arm64: 1.10.14
-      turbo-linux-64: 1.10.14
-      turbo-linux-arm64: 1.10.14
-      turbo-windows-64: 1.10.14
-      turbo-windows-arm64: 1.10.14
+      turbo-darwin-64: 1.10.15
+      turbo-darwin-arm64: 1.10.15
+      turbo-linux-64: 1.10.15
+      turbo-linux-arm64: 1.10.15
+      turbo-windows-64: 1.10.15
+      turbo-windows-arm64: 1.10.15
     dev: true
 
   /tweetnacl/1.0.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,7 @@ importers:
 
   packages/application:
     specifiers:
+      '@bos-web-engine/common': workspace:*
       '@bos-web-engine/container': workspace:*
       '@bos-web-engine/iframe': workspace:*
       '@types/node': ^17.0.12
@@ -78,6 +79,7 @@ importers:
     dependencies:
       '@bos-web-engine/iframe': link:../iframe
     devDependencies:
+      '@bos-web-engine/common': link:../common
       '@bos-web-engine/container': link:../container
       '@types/node': 17.0.45
       '@types/react': 18.2.20
@@ -133,12 +135,14 @@ importers:
 
   packages/container:
     specifiers:
+      '@bos-web-engine/common': workspace:*
       '@types/node': ^17.0.12
       eslint: ^7.32.0
       eslint-config-custom: workspace:*
       tsconfig: workspace:*
       typescript: ^4.5.2
     devDependencies:
+      '@bos-web-engine/common': link:../common
       '@types/node': 17.0.45
       eslint: 7.32.0
       eslint-config-custom: link:../eslint-config-custom
@@ -164,6 +168,7 @@ importers:
 
   packages/iframe:
     specifiers:
+      '@bos-web-engine/common': workspace:*
       '@bos-web-engine/container': workspace:*
       '@types/node': ^17.0.12
       '@types/react': ^18.0.17
@@ -176,6 +181,7 @@ importers:
     dependencies:
       '@bos-web-engine/container': link:../container
     devDependencies:
+      '@bos-web-engine/common': link:../common
       '@types/node': 17.0.45
       '@types/react': 18.2.20
       '@types/react-dom': 18.2.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,24 @@ importers:
       tsconfig: link:../tsconfig
       typescript: 4.9.5
 
+  packages/common:
+    specifiers:
+      '@types/node': ^17.0.12
+      '@types/react': ^18.2.25
+      eslint: ^7.32.0
+      eslint-config-custom: workspace:*
+      react: ^18.2.0
+      tsconfig: workspace:*
+      typescript: ^4.5.2
+    devDependencies:
+      '@types/node': 17.0.45
+      '@types/react': 18.2.25
+      eslint: 7.32.0
+      eslint-config-custom: link:../eslint-config-custom
+      react: 18.2.0
+      tsconfig: link:../tsconfig
+      typescript: 4.9.5
+
   packages/compiler:
     specifiers:
       '@babel/standalone': ^7.22.14
@@ -1882,6 +1900,14 @@ packages:
 
   /@types/react/18.2.20:
     resolution: {integrity: sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.3
+      csstype: 3.1.2
+    dev: true
+
+  /@types/react/18.2.25:
+    resolution: {integrity: sha512-24xqse6+VByVLIr+xWaQ9muX1B4bXJKXBbjszbld/UEDslGLY53+ZucF44HCmLbMPejTzGG9XgR+3m2/Wqu1kw==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3


### PR DESCRIPTION
This PR replaces the `isTrusted` flag with an object under `trust` to accommodate more complex loading strategies in the future. Fixes #72 

Before:
```jsx
<Widget isTrusted ... />
```

After:
```jsx
<Widget trust={{ mode: "trusted" }} ... />
```

The options in the current implementation are implemented here as values for `mode`: `sandboxed` or `trusted`. In the updated implementation (#73), Components without a value specified are assumed to be `sandboxed`.

As part of this PR I've also included a ~trust-author~ `trusted-author` trust mode, which treats all Components as trusted if they have the same author as the Component loaded with this trust mode. However explicitly indicating `sandboxed` mode overrides this blanket trust for individual Components and their descendants:
```jsx
{/* Root Component  */}
<Widget trust={{ mode: "trusted-author" }} src="ex.near/widget/Parent" />


{/* Parent Component  */}
<>
  {/* ✅ same author - trusted  */}
  <Widget src="ex.near/widget/X" />

  {/* ✅ same author, explicitly trusted - trusted (**descendants of Y authored by ex.near will still be trusted**) */}
  <Widget src="ex.near/widget/Y" trust={{ mode: "trusted" }} />

  {/* ❌  same author, explicitly sandboxed - sandboxed */}
  <Widget src="ex.near/widget/X" trust={{ mode: "sandboxed" }} />

  {/* ❌  different author, no trust specified - sandboxed */}
  <Widget src="mal.near/widget/X" />
</>
```

We can merge this without ~trust-author~ `trusted-author`, I've included it here because:
- the implementation was pretty simple
- it will be very useful for debugging