### PR TITLE
add code inspector panel

### DIFF
--- a/apps/web/components/Inspector.tsx
+++ b/apps/web/components/Inspector.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import styled from 'styled-components';
+
+import { useComponentSourcesStore } from '../stores/component-sources';
+
+const SidebarButton = styled.button<{ $selected?: boolean }>`
+  background-color: ${(props) =>
+    props.$selected ? 'rebeccapurple' : 'transparent'};
+  padding: 0.5rem;
+  border: 1px solid transparent;
+  border-bottom: 1px solid black;
+  color: white;
+  text-align: left;
+  overflow-wrap: break-word;
+  &:hover {
+    border: 1px solid white;
+  }
+`;
+
+const CloseButton = styled.button`
+  background-color: #343028;
+  position: absolute;
+  top: 0;
+  right: 1.5rem;
+  padding: 0.5rem;
+  border: 1px solid transparent;
+  border-bottom: 1px solid black;
+  color: white;
+  text-align: left;
+  &:hover {
+    border: 1px solid white;
+  }
+`;
+
+const OpenButton = styled.button`
+  background-color: #343028;
+  position: fixed;
+  bottom: 0;
+  right: 1.5rem;
+  padding: 0.5rem;
+  border: 1px solid transparent;
+  border-bottom: 1px solid black;
+  color: white;
+  text-align: left;
+  &:hover {
+    border: 1px solid white;
+  }
+  border-radius: 0.5rem 0.5rem 0 0;
+`;
+
+const ComponentList = styled.div`
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  width: 20rem;
+  background-color: #343028;
+  overflow-y: auto;
+`;
+
+const Panel = styled.div<{ $show?: boolean }>`
+  display: ${(props) => (props.$show ? 'flex' : 'none')};
+  flex-direction: row;
+  width: 100vw;
+  height: 40vh;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  border-top: 1px solid black;
+`;
+
+export function Inspector() {
+  // at some point this state may be hoisted, but for now this component handles
+  // its own visibility
+  const [show, setShow] = useState(false);
+
+  const componentSources = useComponentSourcesStore((state) => state.sources);
+
+  // path of selected component, will need to be modified once we support version locking
+  // since it will be possible to have multiple versions of the same component
+  const [selectedComponent, setSelectedComponent] = useState<string>();
+
+  if (!show) {
+    return (
+      <OpenButton
+        onClick={() => {
+          setShow(true);
+        }}
+      >
+        Code
+      </OpenButton>
+    );
+  }
+
+  return (
+    <Panel $show={show}>
+      <ComponentList>
+        {Object.keys(componentSources)
+          .sort()
+          .map((path) => {
+            console.log('path', path);
+            return (
+              <SidebarButton
+                key={path}
+                onClick={() => {
+                  setSelectedComponent(path);
+                }}
+                $selected={selectedComponent === path}
+              >
+                {path}
+              </SidebarButton>
+            );
+          })}
+      </ComponentList>
+      <div
+        style={{
+          flex: 1,
+          height: '100%',
+        }}
+      >
+        <CloseButton
+          onClick={() => {
+            setShow(false);
+          }}
+        >
+          Close
+        </CloseButton>
+        <SyntaxHighlighter
+          language="jsx"
+          style={oneDark}
+          wrapLongLines={true}
+          customStyle={{
+            height: '100%',
+            margin: 0,
+            borderRadius: 0,
+          }}
+          showLineNumbers={true}
+        >
+          {selectedComponent
+            ? componentSources[selectedComponent]
+            : '// select a component from the list to inspect'}
+        </SyntaxHighlighter>
+      </div>
+    </Panel>
+  );
+}

--- a/apps/web/components/Inspector.tsx
+++ b/apps/web/components/Inspector.tsx
@@ -100,7 +100,6 @@ export function Inspector() {
         {Object.keys(componentSources)
           .sort()
           .map((path) => {
-            console.log('path', path);
             return (
               <SidebarButton
                 key={path}

--- a/apps/web/hooks/useWebEngine.ts
+++ b/apps/web/hooks/useWebEngine.ts
@@ -23,6 +23,7 @@ import ReactDOM from 'react-dom/client';
 
 import { useComponentMetrics } from './useComponentMetrics';
 import { useFlags } from './useFlags';
+import { useComponentSourcesStore } from '../stores/component-sources';
 
 interface UseWebEngineParams {
   rootComponentPath?: string;
@@ -199,6 +200,8 @@ export function useWebEngine({
     );
   }, [rootComponentPath]);
 
+  const addSource = useComponentSourcesStore((store) => store.addSource);
+
   useEffect(() => {
     if (!rootComponentPath || !isValidRootComponentPath) {
       return;
@@ -220,11 +223,20 @@ export function useWebEngine({
       compiler.onmessage = ({
         data,
       }: MessageEvent<ComponentCompilerResponse>) => {
-        const { componentId, componentSource, error: loadError } = data;
+        const {
+          componentId,
+          componentSource,
+          rawSource,
+          componentPath,
+          error: loadError,
+        } = data;
+
         if (loadError) {
           setError(loadError.message);
           return;
         }
+
+        addSource(componentPath, rawSource);
 
         const component = {
           ...components[componentId],
@@ -253,6 +265,7 @@ export function useWebEngine({
     error,
     isValidRootComponentPath,
     flags?.bosLoaderUrl,
+    addSource,
   ]);
 
   return {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   reactStrictMode: true,
   transpilePackages: ['ui'],
+  compiler: {
+    styledComponents: true,
+  },
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,13 +20,16 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.46.2",
+    "react-syntax-highlighter": "^15.5.0",
     "styled-components": "^6.0.8",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "zustand": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^17.0.12",
     "@types/react": "^18.0.22",
     "@types/react-dom": "^18.0.7",
+    "@types/react-syntax-highlighter": "^15.5.8",
     "@types/uuid": "^9.0.1",
     "bootstrap": "^5.3.0",
     "bootstrap-icons": "^1.10.5",

--- a/apps/web/pages/[[...root]].tsx
+++ b/apps/web/pages/[[...root]].tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 import { ComponentTree } from '../components';
+import { Inspector } from '../components/Inspector';
 import { useWebEngine } from '../hooks';
 
 const DEFAULT_COMPONENT = process.env.NEXT_PUBLIC_DEFAULT_ROOT_COMPONENT;
@@ -43,6 +44,7 @@ export default function Root() {
           showMonitor={showMonitor}
         />
       )}
+      <Inspector />
     </div>
   );
 }

--- a/apps/web/stores/component-sources.ts
+++ b/apps/web/stores/component-sources.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+interface SourcesState {
+  sources: Record<string, string>;
+  addSource: (path: string, source: string) => void;
+  clearSources: () => void;
+}
+
+export const useComponentSourcesStore = create<SourcesState>((set) => ({
+  sources: {},
+  addSource: (path, source) =>
+    set((state) => ({ sources: { ...state.sources, [path]: source } })),
+  clearSources: () => set({ sources: {} }),
+}));

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -25,6 +25,8 @@ interface CompilerInitAction {
 export interface ComponentCompilerResponse {
   componentId: string;
   componentSource: string;
+  rawSource: string;
+  componentPath: string;
   error?: Error;
 }
 
@@ -285,6 +287,8 @@ export class ComponentCompiler {
     this.sendWorkerMessage({
       componentId,
       componentSource,
+      rawSource: source,
+      componentPath,
     });
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ importers:
       '@types/node': ^17.0.12
       '@types/react': ^18.0.22
       '@types/react-dom': ^18.0.7
+      '@types/react-syntax-highlighter': ^15.5.8
       '@types/uuid': ^9.0.1
       bootstrap: ^5.3.0
       bootstrap-icons: ^1.10.5
@@ -37,10 +38,12 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0
       react-hook-form: ^7.46.2
+      react-syntax-highlighter: ^15.5.0
       styled-components: ^6.0.8
       tsconfig: workspace:*
       typescript: ^4.5.3
       uuid: ^9.0.0
+      zustand: ^4.4.3
     dependencies:
       '@bos-web-engine/application': link:../../packages/application
       '@bos-web-engine/compiler': link:../../packages/compiler
@@ -50,12 +53,15 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-hook-form: 7.46.2_react@18.2.0
+      react-syntax-highlighter: 15.5.0_react@18.2.0
       styled-components: 6.0.8_biqbaboplfbrettd7655fr4n2y
       uuid: 9.0.0
+      zustand: 4.4.3_j3ahe22lw6ac2w6qvqp4kjqnqy
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.2.20
       '@types/react-dom': 18.2.7
+      '@types/react-syntax-highlighter': 15.5.8
       '@types/uuid': 9.0.2
       bootstrap: 5.3.1
       bootstrap-icons: 1.10.5
@@ -1892,6 +1898,12 @@ packages:
       - supports-color
     dev: true
 
+  /@types/hast/2.3.6:
+    resolution: {integrity: sha512-47rJE80oqPmFdVDCD7IheXBrVdwuBgsYwoczFvKmwfo2Mzsnt+V9OONsYauFmICb6lQPpCuXYJWejBNs4pDJRg==}
+    dependencies:
+      '@types/unist': 2.0.8
+    dev: false
+
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: false
@@ -1902,12 +1914,17 @@ packages:
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: true
 
   /@types/react-dom/18.2.7:
     resolution: {integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==}
     dependencies:
       '@types/react': 18.2.20
+    dev: true
+
+  /@types/react-syntax-highlighter/15.5.8:
+    resolution: {integrity: sha512-GT1PLGzhF3ilGaQiCHFDShxDBb014s01MQi0nWfXJ23efjWfUrZ2i0g4tH1JGdfnIGBtQDge/k3ON3fLoAuU/w==}
+    dependencies:
+      '@types/react': 18.2.25
     dev: true
 
   /@types/react/18.2.20:
@@ -1916,7 +1933,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
-    dev: true
 
   /@types/react/18.2.25:
     resolution: {integrity: sha512-24xqse6+VByVLIr+xWaQ9muX1B4bXJKXBbjszbld/UEDslGLY53+ZucF44HCmLbMPejTzGG9XgR+3m2/Wqu1kw==}
@@ -1928,10 +1944,13 @@ packages:
 
   /@types/scheduler/0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
-    dev: true
 
   /@types/stylis/4.2.1:
     resolution: {integrity: sha512-OSaMrXUKxVigGlKRrET39V2xdhzlztQ9Aqumn1WbCBKHOi9ry7jKSd7rkyj0GzmWaU960Rd+LpOFpLfx5bMQAg==}
+    dev: false
+
+  /@types/unist/2.0.8:
+    resolution: {integrity: sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==}
     dev: false
 
   /@types/uuid/9.0.2:
@@ -2314,6 +2333,18 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  /character-entities-legacy/1.1.4:
+    resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+    dev: false
+
+  /character-entities/1.2.4:
+    resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
+    dev: false
+
+  /character-reference-invalid/1.1.4:
+    resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
+    dev: false
+
   /chokidar/3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -2350,6 +2381,10 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  /comma-separated-tokens/1.0.8:
+    resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
+    dev: false
 
   /commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -2974,6 +3009,12 @@ packages:
       reusify: 1.0.4
     dev: false
 
+  /fault/1.0.4:
+    resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+    dependencies:
+      format: 0.2.2
+    dev: false
+
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3010,6 +3051,11 @@ packages:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
     dev: true
+
+  /format/0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
+    dev: false
 
   /fs-readdir-recursive/1.1.0:
     resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
@@ -3190,6 +3236,24 @@ packages:
       function-bind: 1.1.1
     dev: false
 
+  /hast-util-parse-selector/2.2.5:
+    resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
+    dev: false
+
+  /hastscript/6.0.0:
+    resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
+    dependencies:
+      '@types/hast': 2.3.6
+      comma-separated-tokens: 1.0.8
+      hast-util-parse-selector: 2.2.5
+      property-information: 5.6.0
+      space-separated-tokens: 1.1.5
+    dev: false
+
+  /highlight.js/10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+    dev: false
+
   /http-errors/1.8.1:
     resolution: {integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==}
     engines: {node: '>= 0.6'}
@@ -3252,6 +3316,17 @@ packages:
       side-channel: 1.0.4
     dev: false
 
+  /is-alphabetical/1.0.4:
+    resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
+    dev: false
+
+  /is-alphanumerical/1.0.4:
+    resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+    dependencies:
+      is-alphabetical: 1.0.4
+      is-decimal: 1.0.4
+    dev: false
+
   /is-array-buffer/3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
     dependencies:
@@ -3300,6 +3375,10 @@ packages:
       has-tostringtag: 1.0.0
     dev: false
 
+  /is-decimal/1.0.4:
+    resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
+    dev: false
+
   /is-extglob/2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3313,6 +3392,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
+
+  /is-hexadecimal/1.0.4:
+    resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
+    dev: false
 
   /is-negative-zero/2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
@@ -3475,6 +3558,13 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+
+  /lowlight/1.20.0:
+    resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
+    dependencies:
+      fault: 1.0.4
+      highlight.js: 10.7.3
+    dev: false
 
   /lru-cache/10.0.1:
     resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
@@ -3744,6 +3834,17 @@ packages:
     dependencies:
       callsites: 3.1.0
 
+  /parse-entities/2.0.0:
+    resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+    dependencies:
+      character-entities: 1.2.4
+      character-entities-legacy: 1.1.4
+      character-reference-invalid: 1.1.4
+      is-alphanumerical: 1.0.4
+      is-decimal: 1.0.4
+      is-hexadecimal: 1.0.4
+    dev: false
+
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -3817,6 +3918,16 @@ packages:
     hasBin: true
     dev: true
 
+  /prismjs/1.27.0:
+    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /prismjs/1.29.0:
+    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
+    engines: {node: '>=6'}
+    dev: false
+
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -3827,6 +3938,12 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+    dev: false
+
+  /property-information/5.6.0:
+    resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
+    dependencies:
+      xtend: 4.0.2
     dev: false
 
   /punycode/2.3.0:
@@ -3860,6 +3977,19 @@ packages:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: false
 
+  /react-syntax-highlighter/15.5.0_react@18.2.0:
+    resolution: {integrity: sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==}
+    peerDependencies:
+      react: '>= 0.14.0'
+    dependencies:
+      '@babel/runtime': 7.22.10
+      highlight.js: 10.7.3
+      lowlight: 1.20.0
+      prismjs: 1.29.0
+      react: 18.2.0
+      refractor: 3.6.0
+    dev: false
+
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -3873,6 +4003,14 @@ packages:
       picomatch: 2.3.1
     dev: false
     optional: true
+
+  /refractor/3.6.0:
+    resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
+    dependencies:
+      hastscript: 6.0.0
+      parse-entities: 2.0.0
+      prismjs: 1.27.0
+    dev: false
 
   /regenerate-unicode-properties/10.1.1:
     resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
@@ -4078,6 +4216,10 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
+
+  /space-separated-tokens/1.1.5:
+    resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
+    dev: false
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -4486,6 +4628,14 @@ packages:
     dependencies:
       punycode: 2.3.0
 
+  /use-sync-external-store/1.2.0_react@18.2.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /uuid/9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
@@ -4563,6 +4713,11 @@ packages:
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  /xtend/4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+    dev: false
+
   /yallist/3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -4571,3 +4726,23 @@ packages:
 
   /zod/3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+
+  /zustand/4.4.3_j3ahe22lw6ac2w6qvqp4kjqnqy:
+    resolution: {integrity: sha512-oRy+X3ZazZvLfmv6viIaQmtLOMeij1noakIsK/Y47PWYhT8glfXzQ4j0YcP5i0P0qI1A4rIB//SGROGyZhx91A==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@types/react': 18.2.20
+      react: 18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
+    dev: false


### PR DESCRIPTION
closes #56 

Creates an always-present, collapsible code inspector panel for viewing original component source. In the future, we may want to drive this by a flag of some sort in order to ensure it is not affecting performance, but for now we gain more by having it always running so users discover it naturally instead of needing to go looking for it.

![Screenshot 2023-10-18 at 12 28 19 PM](https://github.com/near/bos-web-engine/assets/24904709/53073745-d958-40f0-b046-c1685ee7af50)

![Screenshot 2023-10-18 at 12 28 23 PM](https://github.com/near/bos-web-engine/assets/24904709/0f17b767-fb20-4ea6-8b12-3caff8c7556e)

Also adds Zustand for basic global state management. If we end up expanding its usage, we can learn from the [Pagoda Console implementation](https://github.com/near/pagoda-console/tree/develop/frontend/stores)