### PR TITLE
add lib to turbo cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "env": ["NEXT_PUBLIC_DEFAULT_ROOT_COMPONENT"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "lib/**"]
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
several of our packages build to `lib` and they were not being cached by turborepo, causing them to be missing when Vercel has a cache hit on those packages

should resolve our intermittent build failures