### PR TITLE
fix: inline stringified JSON props directly

### DIFF
--- a/packages/container/src/container.ts
+++ b/packages/container/src/container.ts
@@ -146,9 +146,7 @@ export function initContainer({
     componentId,
     props: deserializeProps({
       componentId,
-      props: JSON.parse(
-        `${componentPropsJson.replace(/'/g, "\\'").replace(/\\"/g, '\\\\"')}`
-      ),
+      props: componentPropsJson,
     }),
   });
 

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -267,7 +267,7 @@ export interface InitContainerParams {
   context: {
     Component: Function;
     componentId: string;
-    componentPropsJson: string;
+    componentPropsJson: object;
     ContainerComponent: Function;
     createElement: PreactCreateElement;
     parentContainerId: string | null;

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -29,7 +29,7 @@ function buildSandboxedComponent({
   parentContainerId,
 }: SandboxedIframeProps) {
   const componentPropsJson = componentProps
-    ? encodeJsonString(JSON.stringify(componentProps))
+    ? JSON.stringify(componentProps)
     : '{}';
 
   return `
@@ -101,7 +101,7 @@ function buildSandboxedComponent({
             context: {
               Component: Widget,
               componentId: '${id}',
-              componentPropsJson: '${componentPropsJson}',
+              componentPropsJson: ${componentPropsJson},
               /* "function BWEComponent() {...}" is added to module scope when [scriptSrc] is interpolated */
               ContainerComponent: BWEComponent,
               createElement,


### PR DESCRIPTION
Fixes #112 

I was mistaken about the root cause for this initially, turns out all that's needed is to inline the stringified JSON when passing as an argument. I had broken it in the refactor to get JS out of the iframe container template string, but this solution removes a lot of unnecessary jank and clears the way for removing the encoding functions altogether 🎉 