### PR TITLE
feat: imports

### DIFF
--- a/apps/web/components/ComponentTree.tsx
+++ b/apps/web/components/ComponentTree.tsx
@@ -37,7 +37,10 @@ export default function ComponentTree({
           {Object.entries(components)
             .filter(([, component]) => !!component?.componentSource)
             .map(
-              ([componentId, { trust, props, componentSource, parentId }]) => (
+              ([
+                componentId,
+                { trust, props, componentSource, parentId, moduleImports },
+              ]) => (
                 <div key={componentId} component-id={componentId}>
                   <SandboxedIframe
                     id={getIframeId(componentId)}
@@ -45,6 +48,7 @@ export default function ComponentTree({
                     scriptSrc={componentSource}
                     componentProps={props}
                     parentContainerId={parentId}
+                    moduleImports={moduleImports}
                   />
                 </div>
               )

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -135,10 +135,7 @@ export class ComponentCompiler {
       extractImportStatements(componentSource);
 
     const componentImports = imports
-      .map(
-        (moduleImport) =>
-          buildComponentImportStatements(moduleImport).statements
-      )
+      .map((moduleImport) => buildComponentImportStatements(moduleImport))
       .flat()
       .filter((statement) => !!statement) as string[];
 

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -268,9 +268,12 @@ export class ComponentCompiler {
       .flat();
 
     const importedModules = [
-      ...new Set(containerModuleImports.map(({ module }) => module)),
-    ].reduce((modules, module) => {
-      modules.set(module, buildModulePackageUrl(module, this.preactVersion!));
+      ...new Set(containerModuleImports.map(({ moduleName }) => moduleName)),
+    ].reduce((modules, moduleName) => {
+      modules.set(
+        moduleName,
+        buildModulePackageUrl(moduleName, this.preactVersion!)
+      );
       return modules;
     }, new Map<string, string>());
 

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -266,7 +266,7 @@ export class ComponentCompiler {
     const containerModuleImports = [...transformedComponents.values()]
       .map(({ imports }) => imports)
       .flat();
-    const importStatements = buildModuleImports(containerModuleImports);
+
     const importedModules = [
       ...new Set(containerModuleImports.map(({ module }) => module)),
     ].reduce((modules, module) => {
@@ -275,7 +275,7 @@ export class ComponentCompiler {
     }, new Map<string, string>());
 
     const componentSource = [
-      ...importStatements,
+      ...buildModuleImports(containerModuleImports),
       ...[...transformedComponents.values()].map(
         ({ transpiled }) => transpiled
       ),

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -7,55 +7,15 @@ import {
 import { parseChildComponents, ParsedChildComponent } from './parser';
 import { fetchComponentSources } from './source';
 import { transpileSource } from './transpile';
-
-export type ComponentCompilerRequest =
-  | CompilerExecuteAction
-  | CompilerInitAction;
-
-interface CompilerExecuteAction {
-  action: 'execute';
-  componentId: string;
-}
-
-interface CompilerInitAction {
-  action: 'init';
-  localFetchUrl?: string;
-}
-
-export interface ComponentCompilerResponse {
-  componentId: string;
-  componentSource: string;
-  rawSource: string;
-  componentPath: string;
-  error?: Error;
-}
-
-type SendMessageCallback = (res: ComponentCompilerResponse) => void;
-
-interface ComponentCompilerParams {
-  sendMessage: SendMessageCallback;
-}
-
-interface TranspiledComponentLookupParams {
-  componentPath: string;
-  componentSource: string;
-  isRoot: boolean;
-}
-
-interface ParseComponentTreeParams {
-  mapped: { [key: string]: { transpiled: string } };
-  transpiledComponent: string;
-  componentPath: string;
-  isComponentPathTrusted?: (path: string) => boolean;
-  trustedRoot?: TrustedRoot;
-}
-
-interface TrustedRoot {
-  rootPath: string;
-  trustMode: string;
-  /* predicates for determining trust under a trusted root */
-  matchesRootAuthor: (path: string) => boolean;
-}
+import type {
+  CompilerExecuteAction,
+  CompilerInitAction,
+  ComponentCompilerParams,
+  ParseComponentTreeParams,
+  SendMessageCallback,
+  TranspiledComponentLookupParams,
+  TrustedRoot,
+} from './types';
 
 export class ComponentCompiler {
   private bosSourceCache: Map<string, Promise<string>>;

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -267,15 +267,28 @@ export class ComponentCompiler {
       .map(({ imports }) => imports)
       .flat();
 
-    const importedModules = [
-      ...new Set(containerModuleImports.map(({ moduleName }) => moduleName)),
-    ].reduce((modules, moduleName) => {
-      modules.set(
-        moduleName,
-        buildModulePackageUrl(moduleName, this.preactVersion!)
-      );
-      return modules;
-    }, new Map<string, string>());
+    const importedModules = containerModuleImports.reduce(
+      (importMap, { moduleName, modulePath }) => {
+        const importMapEntries = buildModulePackageUrl(
+          moduleName,
+          modulePath,
+          this.preactVersion!
+        );
+
+        if (!importMapEntries) {
+          return importMap;
+        }
+
+        const moduleEntry = importMap.get(moduleName);
+        if (moduleEntry) {
+          return importMap;
+        }
+
+        importMap.set(importMapEntries.moduleName, importMapEntries.url);
+        return importMap;
+      },
+      new Map<string, string>()
+    );
 
     const componentSource = [
       ...buildModuleImports(containerModuleImports),

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -12,21 +12,25 @@ export function buildComponentFunctionName(componentPath?: string) {
 }
 
 interface BuildComponentFunctionParams {
+  componentImports: string[];
   componentPath: string;
   componentSource: string;
   isRoot: boolean;
 }
 
 export function buildComponentFunction({
+  componentImports,
   componentPath,
   componentSource,
   isRoot,
 }: BuildComponentFunctionParams) {
   const functionName = buildComponentFunctionName(isRoot ? '' : componentPath);
+  const importAssignments = componentImports.join('\n');
 
   if (isRoot) {
     return `
       function ${functionName}() {
+        ${importAssignments}
         ${componentSource}
       }
     `;
@@ -35,6 +39,7 @@ export function buildComponentFunction({
   return `
     /************************* ${componentPath} *************************/
     function ${functionName}(__bweInlineComponentProps) {
+      ${importAssignments}
       const { __bweMeta, props: __componentProps } = __bweInlineComponentProps;
       const props = Object.assign({ __bweMeta }, __componentProps); 
       ${componentSource}

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -1,0 +1,266 @@
+// mapping of component IDs to the set of statements
+// required to assign aliases to imported references
+type ComponentImports = Map<string, string[]>;
+
+// imported references for a single Component
+interface BOSComponent {
+  componentId: string;
+  importReferences?: (ImportExpression | null)[];
+  source: string;
+}
+
+// container-wide imports
+interface ContainerImport {
+  statement: string;
+  imports: ComponentImports;
+}
+
+// structured representation of import statement
+interface ImportExpression {
+  alias?: string;
+  isDefault?: boolean;
+  isDestructured?: boolean;
+  isNamespace?: boolean;
+  reference?: string;
+}
+
+interface ImportTypes {
+  topLevelImports: ImportExpression[];
+  destructuredImports: ImportExpression[];
+}
+
+/**
+ * Aggregate imports for all modules across all referencing Components
+ * @param components set of Components within a container
+ *
+ * @return container and component-level import and assignment statements for all imported modules
+ */
+export const buildModuleImports = (
+  components: BOSComponent[]
+): ContainerImport => {
+  const componentImports = components.map((component) => ({
+    ...component,
+    imports: component.source
+      .split('\n')
+      .filter((line) => line.startsWith('import '))
+      .map(parseImport),
+  }));
+
+  const moduleReferences = componentImports.reduce(
+    (importsByModule, { componentId, imports }) => {
+      for (let { importReferences, module } of imports) {
+        if (!importsByModule.has(module)) {
+          importsByModule.set(module, []);
+        }
+        importsByModule.get(module).push({
+          componentId,
+          importReferences,
+        });
+      }
+
+      return importsByModule;
+    },
+    new Map()
+  );
+
+  const containerImports: ContainerImport = {
+    statement: '',
+    imports: new Map<string, string[]>(),
+  };
+
+  moduleReferences.forEach((components, module) => {
+    const { statement, imports } = aggregateModuleImports(module, components);
+    containerImports.statement += `${statement}\n`;
+    imports.forEach((importStatements, componentId) => {
+      if (!containerImports.imports.has(componentId)) {
+        containerImports.imports.set(componentId, []);
+      }
+
+      const componentImports = containerImports.imports
+        .get(componentId)!
+        .concat(importStatements);
+      containerImports.imports.set(componentId, componentImports);
+    });
+  });
+
+  return containerImports;
+};
+
+/**
+ * For the given module, construct the import statements at the container level
+ * and assignment statements for each Component referencing this module
+ * @param module name of the module being imported
+ * @param components set of BOS Components referencing this module
+ *
+ * @return container and component-level import and assignment statements for the given module
+ */
+const aggregateModuleImports = (
+  module: string,
+  components: BOSComponent[]
+): ContainerImport => {
+  const bweAlias = `__BWEModule__${module}`;
+  const bweNamespacedAlias = `__BWEModule__namespaced__${module}`;
+  let hasNamespace = false;
+
+  const imports = components.reduce(
+    (componentImports, { componentId, importReferences }) => {
+      if (!componentImports.has(componentId)) {
+        componentImports.set(componentId, []);
+      }
+
+      if (!importReferences) {
+        return componentImports;
+      }
+
+      const { topLevelImports, destructuredImports } = importReferences.reduce(
+        (importTypes: ImportTypes, ref: ImportExpression | null) => {
+          if (!ref) {
+            return importTypes;
+          }
+
+          if (ref.isDestructured) {
+            importTypes.destructuredImports.push(ref);
+          } else {
+            importTypes.topLevelImports.push(ref);
+          }
+
+          return importTypes;
+        },
+        { topLevelImports: [], destructuredImports: [] }
+      );
+
+      const topLevelStatements = topLevelImports.map(
+        ({ alias, isDefault, isNamespace, reference }: ImportExpression) => {
+          // import X from 'x'
+          if (isDefault) {
+            return `const ${reference} = ${bweAlias};`;
+          }
+
+          // import * as X from 'x'
+          if (isNamespace && alias) {
+            hasNamespace = true;
+            return `const ${alias} = ${bweNamespacedAlias}`;
+          }
+        }
+      );
+
+      const destructuredReferences = destructuredImports
+        .map(({ alias, reference }: ImportExpression) => {
+          // import { X as x } from 'x'
+          if (alias) {
+            return `${reference}: ${alias}`;
+          }
+
+          // import { X } from 'x'
+          return reference;
+        })
+        .join(', ');
+
+      const destructuredAssignment = destructuredReferences.length
+        ? `const { ${destructuredReferences} } = ${bweAlias};`
+        : null;
+
+      componentImports.set(componentId, [
+        ...topLevelStatements,
+        ...(destructuredAssignment ? [destructuredAssignment] : []),
+      ]);
+
+      return componentImports;
+    },
+    new Map()
+  );
+
+  let containerImportComponents = [`import ${bweAlias}`, `from '${module}';`];
+  if (hasNamespace) {
+    containerImportComponents.splice(1, 0, `, * as ${bweNamespacedAlias}`);
+  }
+
+  return {
+    statement: containerImportComponents.join(' '),
+    imports,
+  };
+};
+
+/**
+ * Extract metadata from an import statement
+ * @param importReference imported references, i.e. the bit between `import` and `from`
+ * @param isDestructured flag indicating whether this reference is from a destructured import
+ */
+const parseImportReference = (
+  importReference: string,
+  isDestructured: boolean
+): ImportExpression | null => {
+  const ref = importReference.trim();
+  if (ref.startsWith('*')) {
+    return {
+      isNamespace: true,
+      alias: ref.split(' as ')[1].trim(),
+    };
+  } else if (ref.startsWith('/')) {
+    return null;
+  } else if (ref.includes(' as ')) {
+    const [reference, alias] = ref.split(' as ').map((r) => r.trim());
+    return {
+      alias,
+      reference,
+      isDestructured,
+    };
+  }
+
+  return {
+    reference: ref,
+    isDefault: !isDestructured,
+    isDestructured,
+  };
+};
+
+/**
+ * Extract metadata from an import statement
+ * @param statement import statement
+ */
+const parseImport = (statement: string) => {
+  let parsed = statement.replace('import ', '');
+  if (parsed.endsWith(';')) {
+    parsed = parsed.slice(0, parsed.length - 2);
+  }
+
+  // side-effect import
+  if (!parsed.includes(' from ')) {
+    return { module: parsed.trim().replace(/"'/g, '') };
+  }
+
+  let [imported, module] = parsed.split(' from ');
+  module = module.replace(/["']/g, '');
+
+  let openDestructure = false;
+  const importReferences = imported
+    .split(',')
+    .map((reference) => {
+      let ref = reference.trim();
+      const isOpenBracket = ref.startsWith('{');
+      const isCloseBracket = ref.endsWith('}');
+
+      if (isOpenBracket) {
+        openDestructure = true;
+      }
+
+      const parsedExpression = parseImportReference(
+        ref.slice(isOpenBracket ? 1 : 0, ref.length - (isCloseBracket ? 1 : 0)),
+        openDestructure
+      );
+
+      if (isCloseBracket) {
+        openDestructure = false;
+      }
+
+      return parsedExpression;
+    })
+    .flat()
+    .filter((refMeta) => !!refMeta);
+
+  return {
+    importReferences,
+    module,
+    statement,
+  };
+};

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -20,7 +20,7 @@ const SIDE_EFFECT_IMPORT_REGEX =
 export const extractImportStatements = (source: string) => {
   let src = source.trim();
 
-  const imports = [];
+  const imports: ModuleImport[] = [];
   while (src.startsWith('import')) {
     const [mixedMatch] = [...src.matchAll(MIXED_IMPORT_REGEX)];
     if (mixedMatch) {
@@ -73,6 +73,7 @@ export const extractImportStatements = (source: string) => {
       if (sideEffectMatch) {
         const { module } = sideEffectMatch.groups as ImportModule;
         imports.push({
+          imports: [],
           isSideEffect: true,
           module,
         });
@@ -88,7 +89,7 @@ export const extractImportStatements = (source: string) => {
   }
 
   return {
-    imports: imports as ModuleImport[],
+    imports,
     source: src,
   };
 };
@@ -104,7 +105,7 @@ export const buildModuleImports = (moduleImports: ModuleImport[]): string[] => {
 
   const sideEffectImports = moduleImports
     .filter(({ isSideEffect }) => isSideEffect)
-    .map(({ module }) => `import ${module};`);
+    .map(({ module }) => `import "${module}";`);
 
   const importsByModule = moduleImports.reduce(
     (byModule, { imports, isSideEffect, module }) => {

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -20,14 +20,6 @@ const SIDE_EFFECT_IMPORT_REGEX =
 export const extractImportStatements = (source: string) => {
   let src = source.trim();
 
-  // source does not have top-level `import` statements, return unmodified source
-  if (!src.startsWith('import')) {
-    return {
-      imports: [],
-      source,
-    };
-  }
-
   const imports = [];
   while (src.startsWith('import')) {
     const [mixedMatch] = [...src.matchAll(MIXED_IMPORT_REGEX)];
@@ -185,13 +177,16 @@ interface ImportsByType {
   namespaceImport: ImportExpression;
 }
 
-export const buildComponentImportStatements = (moduleImport: ModuleImport) => {
+/**
+ * Build the set of assignment statements for a Component to reference an imported module
+ * @param moduleImport all imported references for a specific module imported by a Component
+ */
+export const buildComponentImportStatements = (
+  moduleImport: ModuleImport
+): string[] => {
   const { imports, isSideEffect, module } = moduleImport;
   if (isSideEffect) {
-    return {
-      componentImports: [],
-      hasNamespaceImport: false,
-    };
+    return [];
   }
 
   const { defaultAlias, namespaceAlias } = buildModuleAliases(module);
@@ -233,10 +228,7 @@ export const buildComponentImportStatements = (moduleImport: ModuleImport) => {
     throw new Error(`Invalid import for module ${module}`);
   }
 
-  return {
-    statements,
-    hasNamespaceImport: !!namespaceImport,
-  };
+  return statements;
 };
 
 /**

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -254,3 +254,20 @@ const aggregateModuleImports = (imports: ImportExpression[]): ImportsByType => {
     } as ImportsByType
   );
 };
+
+/**
+ * Build the importmap URL based on package name/URL
+ * @param moduleName module name specified in the import statement
+ * @param preactVersion version of Preact dependency
+ */
+export const buildModulePackageUrl = (
+  moduleName: string,
+  preactVersion: string
+) => {
+  // if the value specified is a URL, use that
+  if (moduleName.startsWith('https://')) {
+    return moduleName;
+  }
+
+  return `https://esm.sh/${moduleName}?alias=react:preact/compat&deps=preact@${preactVersion}`;
+};

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -9,9 +9,9 @@ type ImportMixed = ImportModule & {
 
 // valid combinations of default, namespace, and destructured imports
 const MIXED_IMPORT_REGEX =
-  /^import\s+(?<reference>[\w$]+)?\s*,?(\s*\*\s+as\s+(?<namespace>[\w-]+))?(\s*{\s*(?<destructured>[\w\s*\/,$-]+)})?\s+from\s+["'](?<module>[\w@\/-]+)["'];?\s*/gi;
+  /^import\s+(?<reference>[\w$]+)?\s*,?(\s*\*\s+as\s+(?<namespace>[\w-]+))?(\s*{\s*(?<destructured>[\w\s*\/,$-]+)})?\s+from\s+["'](?<module>[\w@\/.-]+)["'];?\s*/gi;
 const SIDE_EFFECT_IMPORT_REGEX =
-  /^import\s+["'](?<module>[\w@\/-]+)["'];?\s*/gi;
+  /^import\s+["'](?<module>[\w@\/.-]+)["'];?\s*/gi;
 
 /**
  * Given BOS Component source code, return an object with the `import`-less source code and array of structured import statements
@@ -163,7 +163,7 @@ export const buildModuleImports = (moduleImports: ModuleImport[]): string[] => {
  */
 const buildModuleAliases = (moduleName: string) => {
   // replace invalid JS identifier chars with _
-  const moduleAlias = moduleName.replace(/[:?&/@-]/g, '_');
+  const moduleAlias = moduleName.replace(/[:?&/@.-]/g, '_');
 
   return {
     defaultAlias: `__BWEModule__${moduleAlias}`,

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -58,13 +58,16 @@ export const buildModuleImports = (
   );
 
   const containerImports: ContainerImport = {
-    statement: '',
+    statements: [],
     imports: new Map<string, string[]>(),
   };
 
   moduleReferences.forEach((components, module) => {
-    const { statement, imports } = aggregateModuleImports(module, components);
-    containerImports.statement += `${statement}\n`;
+    const { statements, imports } = aggregateModuleImports(module, components);
+    containerImports.statements = [
+      ...containerImports.statements,
+      ...statements,
+    ];
     imports.forEach((importStatements, componentId) => {
       if (!containerImports.imports.has(componentId)) {
         containerImports.imports.set(componentId, []);
@@ -179,7 +182,7 @@ const aggregateModuleImports = (
   }
 
   return {
-    statement: containerImportComponents.join(' '),
+    statements: [containerImportComponents.join(' ')],
     imports,
   };
 };
@@ -227,7 +230,7 @@ const parseImport = (statement: string) => {
     parsed = parsed.slice(0, parsed.length - 2);
   }
 
-  // side-effect import
+  // import 'x'
   if (!parsed.includes(' from ')) {
     return { module: parsed.trim().replace(/"'/g, '') };
   }

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -1,33 +1,9 @@
-// mapping of component IDs to the set of statements
-// required to assign aliases to imported references
-type ComponentImports = Map<string, string[]>;
-
-// imported references for a single Component
-interface BOSComponent {
-  componentId: string;
-  importReferences?: (ImportExpression | null)[];
-  source: string;
-}
-
-// container-wide imports
-interface ContainerImport {
-  statement: string;
-  imports: ComponentImports;
-}
-
-// structured representation of import statement
-interface ImportExpression {
-  alias?: string;
-  isDefault?: boolean;
-  isDestructured?: boolean;
-  isNamespace?: boolean;
-  reference?: string;
-}
-
-interface ImportTypes {
-  topLevelImports: ImportExpression[];
-  destructuredImports: ImportExpression[];
-}
+import type {
+  BOSComponent,
+  ContainerImport,
+  ImportExpression,
+  ImportTypes,
+} from './types';
 
 /**
  * Aggregate imports for all modules across all referencing Components

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -77,6 +77,12 @@ export const extractImportStatements = (source: string) => {
           module,
         });
         src = src.replace(sideEffectMatch[0], '');
+      } else {
+        // invalid import
+        console.error(
+          `Could not parse import statement: ${src.slice(0, 255)}...`
+        );
+        break;
       }
     }
   }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,6 +1,6 @@
 export type {
   ComponentCompilerRequest,
   ComponentCompilerResponse,
-} from './compiler';
+} from './types';
 
 export { ComponentCompiler } from './compiler';

--- a/packages/compiler/src/source.ts
+++ b/packages/compiler/src/source.ts
@@ -1,10 +1,7 @@
 import { JsonRpcProvider } from '@near-js/providers';
 import type { CodeResult } from '@near-js/types';
 
-interface SocialComponent {
-  widget: { [name: string]: string };
-}
-type SocialComponentsByAuthor = { [author: string]: SocialComponent };
+import type { SocialComponentsByAuthor } from './types';
 
 const encodeComponentKeyArgs = (componentPaths: string[]) => {
   const bytes = new TextEncoder().encode(

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -59,7 +59,7 @@ export interface BOSComponent {
 
 // container-wide imports
 export interface ContainerImport {
-  statement: string;
+  statements: string[];
   imports: ComponentImports;
 }
 

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -32,10 +32,18 @@ export interface TranspiledComponentLookupParams {
   isRoot: boolean;
 }
 
+export type ComponentMap = Map<string, ComponentTreeNode>;
+
+export interface ComponentTreeNode {
+  imports: ModuleImports[];
+  transpiled: string;
+}
+
 export interface ParseComponentTreeParams {
-  mapped: { [key: string]: { transpiled: string } };
+  mapped: ComponentMap;
   transpiledComponent: string;
   componentPath: string;
+  componentImports: ModuleImports[];
   isComponentPathTrusted?: (path: string) => boolean;
   trustedRoot?: TrustedRoot;
 }
@@ -46,16 +54,14 @@ export interface TrustedRoot {
   /* predicates for determining trust under a trusted root */
   matchesRootAuthor: (path: string) => boolean;
 }
+
+export interface ComponentImport {
+  statements: string[];
+}
+
 // mapping of component IDs to the set of statements
 // required to assign aliases to imported references
-export type ComponentImports = Map<string, string[]>;
-
-// imported references for a single Component
-export interface BOSComponent {
-  componentId: string;
-  importReferences?: (ImportExpression | null)[];
-  source: string;
-}
+export type ComponentImports = Map<string, ComponentImport>;
 
 // container-wide imports
 export interface ContainerImport {
@@ -64,17 +70,19 @@ export interface ContainerImport {
 }
 
 // structured representation of import statement
+export interface ModuleImports {
+  imports: ImportExpression[];
+  isSideEffect?: boolean;
+  module: string;
+}
+
+// structured representation of individual imported reference statement
 export interface ImportExpression {
   alias?: string;
   isDefault?: boolean;
   isDestructured?: boolean;
   isNamespace?: boolean;
   reference?: string;
-}
-
-export interface ImportTypes {
-  topLevelImports: ImportExpression[];
-  destructuredImports: ImportExpression[];
 }
 
 interface SocialComponent {

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -35,7 +35,7 @@ export interface TranspiledComponentLookupParams {
 export type ComponentMap = Map<string, ComponentTreeNode>;
 
 export interface ComponentTreeNode {
-  imports: ModuleImports[];
+  imports: ModuleImport[];
   transpiled: string;
 }
 
@@ -55,22 +55,8 @@ export interface TrustedRoot {
   matchesRootAuthor: (path: string) => boolean;
 }
 
-export interface ComponentImport {
-  statements: string[];
-}
-
-// mapping of component IDs to the set of statements
-// required to assign aliases to imported references
-export type ComponentImports = Map<string, ComponentImport>;
-
-// container-wide imports
-export interface ContainerImport {
-  statements: string[];
-  imports: ComponentImports;
-}
-
 // structured representation of import statement
-export interface ModuleImports {
+export interface ModuleImport {
   imports: ImportExpression[];
   isSideEffect?: boolean;
   module: string;

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -10,6 +10,7 @@ export interface CompilerExecuteAction {
 export interface CompilerInitAction {
   action: 'init';
   localFetchUrl?: string;
+  preactVersion: string;
 }
 
 export interface ComponentCompilerResponse {
@@ -18,6 +19,7 @@ export interface ComponentCompilerResponse {
   rawSource: string;
   componentPath: string;
   error?: Error;
+  importedModules: Map<string, string>;
 }
 
 export type SendMessageCallback = (res: ComponentCompilerResponse) => void;

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -40,11 +40,11 @@ export interface ComponentTreeNode {
 }
 
 export interface ParseComponentTreeParams {
-  mapped: ComponentMap;
-  transpiledComponent: string;
+  components: ComponentMap;
+  componentSource: string;
   componentPath: string;
-  componentImports: ModuleImports[];
   isComponentPathTrusted?: (path: string) => boolean;
+  isRoot: boolean;
   trustedRoot?: TrustedRoot;
 }
 

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -61,7 +61,7 @@ export interface TrustedRoot {
 export interface ModuleImport {
   imports: ImportExpression[];
   isSideEffect?: boolean;
-  module: string;
+  moduleName: string;
 }
 
 // structured representation of individual imported reference statement

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -1,0 +1,84 @@
+export type ComponentCompilerRequest =
+  | CompilerExecuteAction
+  | CompilerInitAction;
+
+export interface CompilerExecuteAction {
+  action: 'execute';
+  componentId: string;
+}
+
+export interface CompilerInitAction {
+  action: 'init';
+  localFetchUrl?: string;
+}
+
+export interface ComponentCompilerResponse {
+  componentId: string;
+  componentSource: string;
+  rawSource: string;
+  componentPath: string;
+  error?: Error;
+}
+
+export type SendMessageCallback = (res: ComponentCompilerResponse) => void;
+
+export interface ComponentCompilerParams {
+  sendMessage: SendMessageCallback;
+}
+
+export interface TranspiledComponentLookupParams {
+  componentPath: string;
+  componentSource: string;
+  isRoot: boolean;
+}
+
+export interface ParseComponentTreeParams {
+  mapped: { [key: string]: { transpiled: string } };
+  transpiledComponent: string;
+  componentPath: string;
+  isComponentPathTrusted?: (path: string) => boolean;
+  trustedRoot?: TrustedRoot;
+}
+
+export interface TrustedRoot {
+  rootPath: string;
+  trustMode: string;
+  /* predicates for determining trust under a trusted root */
+  matchesRootAuthor: (path: string) => boolean;
+}
+// mapping of component IDs to the set of statements
+// required to assign aliases to imported references
+export type ComponentImports = Map<string, string[]>;
+
+// imported references for a single Component
+export interface BOSComponent {
+  componentId: string;
+  importReferences?: (ImportExpression | null)[];
+  source: string;
+}
+
+// container-wide imports
+export interface ContainerImport {
+  statement: string;
+  imports: ComponentImports;
+}
+
+// structured representation of import statement
+export interface ImportExpression {
+  alias?: string;
+  isDefault?: boolean;
+  isDestructured?: boolean;
+  isNamespace?: boolean;
+  reference?: string;
+}
+
+export interface ImportTypes {
+  topLevelImports: ImportExpression[];
+  destructuredImports: ImportExpression[];
+}
+
+interface SocialComponent {
+  widget: { [name: string]: string };
+}
+
+export type SocialComponentsByAuthor = { [author: string]: SocialComponent };

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -62,6 +62,7 @@ export interface ModuleImport {
   imports: ImportExpression[];
   isSideEffect?: boolean;
   moduleName: string;
+  modulePath: string;
 }
 
 // structured representation of individual imported reference statement

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -116,7 +116,7 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
     node: RenderedVNode,
     renderedChildren?: RenderedVNode[],
     childIndex?: number
-  ): VNode {
+  ): VNode | VNode[] {
     if (!node || !renderedChildren) {
       return node;
     }
@@ -127,6 +127,7 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
         fragmentChildren.length === 1 &&
         fragmentChildren[0]?.type === BWEComponent
       ) {
+        // this node is the root of a component defined in the container
         return parseRenderedTree(
           {
             type: 'div',
@@ -137,10 +138,9 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
         );
       }
 
-      return parseRenderedTree(
-        { type: 'div', props: null, key: 'fragment-root' },
-        renderedChildren
-      );
+      return renderedChildren.map((child) =>
+        parseRenderedTree(child)
+      ) as VNode[];
     }
 
     const props =
@@ -207,7 +207,7 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
       parseRenderedTree(
         { type: vnode.type, props: vnode.props, key: 'root-component' },
         vnode.__k
-      )
+      ) as VNode
     );
   };
 

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -17,6 +17,7 @@ function buildSandboxedComponent({
   scriptSrc,
   componentProps,
   parentContainerId,
+  moduleImports,
 }: SandboxedIframeProps) {
   const componentPropsJson = componentProps
     ? JSON.stringify(componentProps)
@@ -26,12 +27,13 @@ function buildSandboxedComponent({
     <html>
       <body>
         <script type="importmap">
-        {
-          "imports": {
-            "preact": "https://esm.sh/preact@10.17.1",
-            "preact/": "https://esm.sh/preact@10.17.1/"
+          {
+            "imports": {
+              ${[...moduleImports.entries()]
+                .map(([module, url]) => `"${module}": "${url}"`)
+                .join(',\n')}
+            }
           }
-        }
         </script>
         <script type="module">
           import * as Preact from 'preact';
@@ -123,6 +125,7 @@ interface SandboxedIframeProps {
   scriptSrc: string;
   componentProps?: any;
   parentContainerId: string | null;
+  moduleImports: Map<string, string>;
 }
 
 export function SandboxedIframe({
@@ -131,6 +134,7 @@ export function SandboxedIframe({
   scriptSrc,
   componentProps,
   parentContainerId,
+  moduleImports,
 }: SandboxedIframeProps) {
   return (
     <iframe
@@ -153,6 +157,7 @@ export function SandboxedIframe({
         scriptSrc,
         componentProps,
         parentContainerId,
+        moduleImports,
       })}
       title="code-container"
       width={0}

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -97,10 +97,10 @@ function buildSandboxedComponent({
           // intialize props
           props = containerProps;
 
-          /* BEGIN BOS SOURCE */
-          /* The root Component definition is inlined here as [function BWEComponent() {...}] */
-          ${scriptSrc}
-          /* END BOS SOURCE */
+/******** BEGIN BOS SOURCE ********/
+/******** The root Component definition is inlined here as [function BWEComponent() {...}] ********/
+${scriptSrc}
+/******** END BOS SOURCE ********/
 
           const oldCommit = Preact.options.__c;
           Preact.options.__c = (vnode, commitQueue) => {


### PR DESCRIPTION
This PR adds support for `import` statements in BOS Components. The functionality is pretty rigid but provides an accessible way to begin testing `import` compatibility.

The functionality being added is meant to make transitions from a React application simpler while granting the flexibility to provide direct URL imports for overriding default behavior and testing. Currently `esm.sh` is the default provider, as it supports dynamic bundling and specification of dependency versions - allowing hooks within the imported package to work within BWE.

Supported syntax:
```js
// imports the current version from esm.sh with bundled Preact
import X from "x";

// imports the specified version from esm.sh with bundled Preact
import X from "x@1.2.3";

// imports the module at the URL directly
import X from "https://esm.sh/x@1.2.3?y=1";
```

This PR does not add the `export` syntax, which will be a breaking change when enforced.