### PR TITLE
feat: allow use of <Component />

### DIFF
--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -1,7 +1,7 @@
 function parseWidgetRenders(transpiledComponent: string) {
   const functionOffset = 'createElement'.length;
   const componentRegex =
-    /createElement\(Widget,\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/[\w.-]+))["|']/gi;
+    /createElement\((?:Widget|Component),\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/[\w.-]+))["|']/gi;
   return [...transpiledComponent.matchAll(componentRegex)].map((match) => {
     const openParenIndex = match.index! + functionOffset;
     let parenCount = 1;
@@ -53,7 +53,7 @@ export function parseChildComponents(
         const signaturePrefix = `${componentName},{__bweMeta:{parentMeta:props.__bweMeta},`;
         return componentSource.replaceAll(
           expression,
-          expression.replace(/Widget,\s*\{/, signaturePrefix)
+          expression.replace(/(Widget|Component),\s*\{/, signaturePrefix)
         );
       },
     };

--- a/packages/container/src/container.ts
+++ b/packages/container/src/container.ts
@@ -20,6 +20,7 @@ export function initContainer({
     parentContainerId,
     trust,
     updateContainerProps,
+    Widget, // TODO remove when <Widget /> no longer supported
   },
 }: InitContainerParams) {
   const callbacks: { [key: string]: Function } = {};
@@ -35,6 +36,8 @@ export function initContainer({
     composeSerializationMethods({
       buildRequest,
       callbacks,
+      isComponent: (c) => c === Component,
+      isWidget: (c) => c === Widget, // TODO remove when <Widget /> no longer supported
       parentContainerId,
       postCallbackInvocationMessage,
       requests,
@@ -45,6 +48,7 @@ export function initContainer({
     isComponent: (c) => c === Component,
     isFragment: (c) => c === Fragment,
     isRootComponent: (c) => c === BWEComponent,
+    isWidget: (c) => c === Widget, // TODO remove when <Widget /> no longer supported
     postComponentRenderMessage,
     serializeNode,
     trust,

--- a/packages/container/src/container.ts
+++ b/packages/container/src/container.ts
@@ -41,10 +41,10 @@ export function initContainer({
     });
 
   const { commit } = composeRenderMethods({
-    BWEComponent,
-    Component,
     componentId,
-    Fragment,
+    isComponent: (c) => c === Component,
+    isFragment: (c) => c === Fragment,
+    isRootComponent: (c) => c === BWEComponent,
     postComponentRenderMessage,
     serializeNode,
     trust,

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -1,4 +1,4 @@
-import type { ComponentChildren, VNode } from 'preact';
+import type { ComponentChildren, ComponentType, VNode } from 'preact';
 
 import type {
   BuildSafeProxyCallback,
@@ -50,10 +50,10 @@ interface RenderedVNode extends VNode<any> {
 type DispatchRenderCallback = (vnode: VNode) => void;
 
 export const composeRenderMethods: ComposeRenderMethodsCallback = ({
-  BWEComponent,
-  Component,
   componentId,
-  Fragment,
+  isRootComponent,
+  isComponent,
+  isFragment,
   postComponentRenderMessage,
   serializeNode,
   trust,
@@ -121,11 +121,11 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
       return node;
     }
 
-    if (node.type === Fragment) {
+    if (isFragment(node.type as ComponentType)) {
       const fragmentChildren = renderedChildren || [];
       if (
         fragmentChildren.length === 1 &&
-        fragmentChildren[0]?.type === BWEComponent
+        isRootComponent(fragmentChildren[0]?.type as ComponentType)
       ) {
         // this node is the root of a component defined in the container
         return parseRenderedTree(
@@ -150,8 +150,8 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
           )
         : node.props;
 
-    if (typeof node.type === 'function' && node.type !== Component) {
-      if (isBWEComponent(node) && node.type !== BWEComponent) {
+    if (typeof node.type === 'function' && isComponent(node.type)) {
+      if (isBWEComponent(node) && !isRootComponent(node.type)) {
         const componentNode = buildBWEComponentNode(
           node as BWEComponentNode,
           renderedChildren

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -54,6 +54,7 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
   isRootComponent,
   isComponent,
   isFragment,
+  isWidget, // TODO remove when <Widget /> no longer supported
   postComponentRenderMessage,
   serializeNode,
   trust,
@@ -150,7 +151,11 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
           )
         : node.props;
 
-    if (typeof node.type === 'function' && isComponent(node.type)) {
+    if (
+      typeof node.type === 'function' &&
+      !isComponent(node.type) &&
+      !isWidget(node.type)
+    ) {
       if (isBWEComponent(node) && !isRootComponent(node.type)) {
         const componentNode = buildBWEComponentNode(
           node as BWEComponentNode,

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -300,6 +300,12 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
           throw new Error(`unrecognized Component function ${type.name}`);
         }
 
+        if (isWidget(type)) {
+          console.warn(
+            '<Widget /> will be deprecated in upcoming versions of BOS Web Engine. Please update your code to reference <Component /> instead.'
+          );
+        }
+
         const { child, placeholder } = serializeChildComponent({
           parentId,
           props,

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -31,6 +31,8 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
   ({
     buildRequest,
     callbacks,
+    isComponent,
+    isWidget,
     parentContainerId,
     postCallbackInvocationMessage,
     requests,
@@ -201,16 +203,16 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
       componentPath,
       parentComponentId,
     }: BuildComponentIdParams) {
-      // TODO warn on missing instanceId (<Widget>'s id prop) here?
+      // TODO warn on missing instanceId (<Component>'s id prop) here?
       return [componentPath, instanceId?.toString(), parentComponentId].join(
         '##'
       );
     }
 
     /**
-     * Serialize a sandboxed <Widget /> component
+     * Serialize a sandboxed <Component /> component
      * @param parentId ID of the parent Component
-     * @param props Props passed to the <Widget /> component
+     * @param props Props passed to the <Component /> component
      */
     const serializeChildComponent = ({
       parentId,
@@ -294,7 +296,7 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
         });
 
       if (typeof type === 'function') {
-        if (type.name !== 'Widget') {
+        if (!isWidget(type) && !isComponent(type)) {
           throw new Error(`unrecognized Component function ${type.name}`);
         }
 

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -155,10 +155,10 @@ export interface ComponentUpdate extends PostMessageParams {
 }
 
 interface ComposeRenderMethodsParams {
-  BWEComponent: FunctionComponent;
-  Component: Function;
   componentId: string;
-  Fragment: FunctionComponent;
+  isComponent: (component: Function) => boolean;
+  isFragment: (component: Function) => boolean;
+  isRootComponent: (component: Function) => boolean;
   postComponentRenderMessage: PostMessageComponentRenderCallback;
   serializeNode: SerializeNodeCallback;
   trust: ComponentTrust;

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -159,6 +159,7 @@ interface ComposeRenderMethodsParams {
   isComponent: (component: Function) => boolean;
   isFragment: (component: Function) => boolean;
   isRootComponent: (component: Function) => boolean;
+  isWidget: (component: Function) => boolean; // TODO remove when <Widget /> no longer supported
   postComponentRenderMessage: PostMessageComponentRenderCallback;
   serializeNode: SerializeNodeCallback;
   trust: ComponentTrust;
@@ -173,6 +174,8 @@ export type ComposeRenderMethodsCallback = (
 export interface ComposeSerializationMethodsParams {
   buildRequest: BuildRequestCallback;
   callbacks: CallbackMap;
+  isComponent: (component: Function) => boolean;
+  isWidget: (component: Function) => boolean; // TODO remove when <Widget /> no longer supported
   parentContainerId: string | null;
   postCallbackInvocationMessage: PostMessageComponentInvocationCallback;
   requests: RequestMap;
@@ -236,6 +239,7 @@ export interface InitContainerParams {
     props: any;
     trust: ComponentTrust;
     updateContainerProps: UpdateContainerPropsCallback;
+    Widget: Function; // TODO remove when <Widget /> no longer supported
   };
 }
 

--- a/packages/iframe/src/SandboxedIframe.tsx
+++ b/packages/iframe/src/SandboxedIframe.tsx
@@ -43,7 +43,8 @@ function buildSandboxedComponent({
 
           const initContainer = ${initContainer.toString()};
 
-          // placeholder to prevent <Widget /> references from breaking 
+          // placeholder function to bind to Component/Widget references 
+          function Component() {}
           function Widget() {}
 
           function useComponentCallback(cb, args) {
@@ -79,7 +80,7 @@ function buildSandboxedComponent({
             },
             context: {
               BWEComponent,
-              Component: Widget,
+              Component,
               componentId: '${id}',
               componentPropsJson: ${componentPropsJson},
               Fragment: Preact.Fragment,
@@ -93,6 +94,7 @@ function buildSandboxedComponent({
                   Preact.render(createElement(BWEComponent), document.body);
                 }
               },
+              Widget,
             },
           });
 


### PR DESCRIPTION
This PR adds the `<Component />` Component, which will eventually replace `<Widget />`. I've implemented them side-by-side here with a warning to begin migrating to `<Component />`.

When we're ready we can phase it out completely by following up with #153