### PR TITLE
feat: deprecate Widget

### DIFF
--- a/packages/application/src/components/SandboxedIframe.tsx
+++ b/packages/application/src/components/SandboxedIframe.tsx
@@ -48,9 +48,8 @@ ${scriptSrc}
 
           const initContainer = ${initContainer.toString()};
 
-          // placeholder function to bind to Component/Widget references 
+          // placeholder function to bind Component references in BOS Component source
           function Component() {}
-          function Widget() {}
 
           function useComponentCallback(cb, args) {
             const [value, setValue] = useState(undefined);
@@ -99,7 +98,6 @@ ${scriptSrc}
                   Preact.render(createElement(BWEComponent, props), document.body);
                 }
               },
-              Widget,
             },
           });
 

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -1,4 +1,4 @@
-function parseWidgetRenders(transpiledComponent: string) {
+function parseComponentRenders(transpiledComponent: string) {
   const functionOffset = 'createElement'.length;
   const componentRegex =
     /createElement\(Component,\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/[\w.-]+))["|']/gi;
@@ -36,9 +36,9 @@ export interface ParsedChildComponent {
 export function parseChildComponents(
   transpiledComponent: string
 ): ParsedChildComponent[] {
-  const widgetRenders = parseWidgetRenders(transpiledComponent);
-  widgetRenders.sort((a, b) => a.index - b.index);
-  return widgetRenders.map(({ expression, index, source }) => {
+  const componentRenders = parseComponentRenders(transpiledComponent);
+  componentRenders.sort((a, b) => a.index - b.index);
+  return componentRenders.map(({ expression, index, source }) => {
     const [trustMatch] = [
       ...expression.matchAll(
         /trust(?:\s*:\s*{(?:[\w\W])*?mode\s*:\s*['"](trusted-author|trusted|sandboxed))/gi

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -1,7 +1,7 @@
 function parseWidgetRenders(transpiledComponent: string) {
   const functionOffset = 'createElement'.length;
   const componentRegex =
-    /createElement\((?:Widget|Component),\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/[\w.-]+))["|']/gi;
+    /createElement\(Component,\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/[\w.-]+))["|']/gi;
   return [...transpiledComponent.matchAll(componentRegex)].map((match) => {
     const openParenIndex = match.index! + functionOffset;
     let parenCount = 1;
@@ -55,7 +55,7 @@ export function parseChildComponents(
         if (!propsMatch?.index) {
           return componentSource.replaceAll(
             expression,
-            expression.replace(/(Widget|Component)/, componentName)
+            expression.replace(/Component/, componentName)
           );
         }
 

--- a/packages/container/src/container.ts
+++ b/packages/container/src/container.ts
@@ -22,7 +22,6 @@ export function initContainer({
     parentContainerId,
     trust,
     updateContainerProps,
-    Widget, // TODO remove when <Widget /> no longer supported
   },
 }: InitContainerParams) {
   const callbacks: { [key: string]: Function } = {};
@@ -39,7 +38,6 @@ export function initContainer({
       buildRequest,
       callbacks,
       isComponent: (c) => c === Component,
-      isWidget: (c) => c === Widget, // TODO remove when <Widget /> no longer supported
       parentContainerId,
       postCallbackInvocationMessage,
       requests,
@@ -50,7 +48,6 @@ export function initContainer({
     isComponent: (c) => c === Component,
     isFragment: (c) => c === Fragment,
     isRootComponent: (c) => c === BWEComponent,
-    isWidget: (c) => c === Widget, // TODO remove when <Widget /> no longer supported
     postComponentRenderMessage,
     serializeNode,
     trust,

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -54,7 +54,6 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
   isRootComponent,
   isComponent,
   isFragment,
-  isWidget, // TODO remove when <Widget /> no longer supported
   postComponentRenderMessage,
   serializeNode,
   trust,
@@ -151,11 +150,7 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
           )
         : node.props;
 
-    if (
-      typeof node.type === 'function' &&
-      !isComponent(node.type) &&
-      !isWidget(node.type)
-    ) {
+    if (typeof node.type === 'function' && !isComponent(node.type)) {
       if (isBWEComponent(node) && !isRootComponent(node.type)) {
         const componentNode = buildBWEComponentNode(
           node as BWEComponentNode,

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -33,7 +33,6 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
     buildRequest,
     callbacks,
     isComponent,
-    isWidget,
     parentContainerId,
     postCallbackInvocationMessage,
     requests,
@@ -297,7 +296,7 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
         });
 
       if (typeof type === 'function') {
-        if (!isWidget(type) && !isComponent(type)) {
+        if (!isComponent(type)) {
           throw new Error(`unrecognized Component function ${type.name}`);
         }
 

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -300,12 +300,6 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
           throw new Error(`unrecognized Component function ${type.name}`);
         }
 
-        if (isWidget(type)) {
-          console.warn(
-            '<Widget /> will be deprecated in upcoming versions of BOS Web Engine. Please update your code to reference <Component /> instead.'
-          );
-        }
-
         const { child, placeholder } = serializeChildComponent({
           parentId,
           props,

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -85,7 +85,6 @@ interface ComposeRenderMethodsParams {
   isComponent: (component: Function) => boolean;
   isFragment: (component: Function) => boolean;
   isRootComponent: (component: Function) => boolean;
-  isWidget: (component: Function) => boolean; // TODO remove when <Widget /> no longer supported
   postComponentRenderMessage: PostMessageComponentRenderCallback;
   serializeNode: SerializeNodeCallback;
   trust: ComponentTrust;
@@ -101,7 +100,6 @@ export interface ComposeSerializationMethodsParams {
   buildRequest: BuildRequestCallback;
   callbacks: CallbackMap;
   isComponent: (component: Function) => boolean;
-  isWidget: (component: Function) => boolean; // TODO remove when <Widget /> no longer supported
   parentContainerId: string | null;
   postCallbackInvocationMessage: PostMessageComponentInvocationCallback;
   requests: RequestMap;
@@ -165,7 +163,6 @@ export interface InitContainerParams {
     props: any;
     trust: ComponentTrust;
     updateContainerProps: UpdateContainerPropsCallback;
-    Widget: Function; // TODO remove when <Widget /> no longer supported
   };
 }
 


### PR DESCRIPTION
This PR removes `<Widget />` as the Component for importing BOS Components. Once merged, only `<Component />` references will be valid.