### PR TITLE
feat: require default or named export

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -133,6 +133,12 @@ export class ComponentCompiler {
     return componentSources;
   }
 
+  /**
+   * Transpile the component and cache for future lookups
+   * @param componentPath path to the BOS Component
+   * @param componentSource source code of the BOS Component
+   * @param isRoot flag indicating whether this is the root Component of a container
+   */
   getTranspiledComponentSource({
     componentPath,
     componentSource,
@@ -152,10 +158,17 @@ export class ComponentCompiler {
     return this.compiledSourceCache.get(cacheKey)!;
   }
 
+  /**
+   * Determine whether a child Component is trusted and can be inlined within the current container
+   * @param trustMode explicit trust mode provided for this child render
+   * @param path child Component's path
+   * @param isComponentPathTrusted flag indicating whether the child is implicitly trusted by virtue of being under a trusted root
+   */
   static isChildComponentTrusted(
     { trustMode, path }: ParsedChildComponent,
     isComponentPathTrusted?: (p: string) => boolean
   ) {
+    // child is explicitly trusted by parent or constitutes a new trusted root
     if (
       trustMode === TrustMode.Trusted ||
       trustMode === TrustMode.TrustAuthor
@@ -163,6 +176,7 @@ export class ComponentCompiler {
       return true;
     }
 
+    // child is explicitly sandboxed
     if (trustMode === TrustMode.Sandboxed) {
       return false;
     }
@@ -280,6 +294,10 @@ export class ComponentCompiler {
     return components;
   }
 
+  /**
+   * Build the source for a container rooted at the target Component
+   * @param componentId ID for the new container's root Component
+   */
   async compileComponent({ componentId }: CompilerExecuteAction) {
     if (this.localFetchUrl && !this.hasFetchedLocal) {
       try {
@@ -310,6 +328,7 @@ export class ComponentCompiler {
       .map(({ imports }) => imports)
       .flat();
 
+    // build the import map used by the container
     const importedModules = containerModuleImports.reduce(
       (importMap, { moduleName, modulePath }) => {
         const importMapEntries = buildModulePackageUrl(

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -76,8 +76,17 @@ export class ComponentCompiler {
 
     // get the exported reference's name and remove the export keyword(s) from Component source
     // TODO halt parsing of the current Component if no export is found
-    const { exported, source: cleanComponentSource } =
-      extractExport(importlessSource);
+    const {
+      exportedReference,
+      hasExport,
+      source: cleanComponentSource,
+    } = extractExport(importlessSource);
+
+    if (!hasExport) {
+      throw new Error(
+        `Could not parse Component ${componentPath}: missing valid Component export`
+      );
+    }
 
     const componentImports = imports
       .map((moduleImport) => buildComponentImportStatements(moduleImport))
@@ -89,7 +98,7 @@ export class ComponentCompiler {
       componentPath,
       componentSource: cleanComponentSource,
       componentImports,
-      exported,
+      exportedReference,
       isRoot,
     });
 

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -15,7 +15,7 @@ interface BuildComponentFunctionParams {
   componentImports: string[];
   componentPath: string;
   componentSource: string;
-  exported: string | null;
+  exportedReference: string | null;
   isRoot: boolean;
 }
 
@@ -23,41 +23,19 @@ export function buildComponentFunction({
   componentImports,
   componentPath,
   componentSource,
-  exported,
+  exportedReference,
   isRoot,
 }: BuildComponentFunctionParams) {
   const functionName = buildComponentFunctionName(isRoot ? '' : componentPath);
   const importAssignments = componentImports.join('\n');
   const commentHeader = `${componentPath} ${isRoot ? '(root)' : ''}`;
 
-  // TODO remove once export is required
-  if (!exported) {
-    if (isRoot) {
-      return `
-        function ${functionName}() {
-          ${importAssignments}
-          ${componentSource}
-        }
-      `;
-    }
-
-    return `
-      /************************* ${componentPath} *************************/
-      function ${functionName}(__bweInlineComponentProps) {
-        ${importAssignments}
-        const { __bweMeta, props: __componentProps } = __bweInlineComponentProps;
-        const props = Object.assign({ __bweMeta }, __componentProps); 
-        ${componentSource}
-      }
-    `;
-  }
-
   return `
     /************************* ${commentHeader} *************************/
     const ${functionName} = (() => {
       ${importAssignments}
       ${componentSource}
-      return ${exported};
+      return ${exportedReference ? exportedReference : 'BWEComponent'};
     })();
   `;
 }

--- a/packages/compiler/src/export.ts
+++ b/packages/compiler/src/export.ts
@@ -1,31 +1,57 @@
 /**
  * Supported export syntax:
  *  - export default X;
- *  - export function X...
- *  - export const X...
+ *  - export function BWEComponent...
+ *  - export const BWEComponent...
  */
 const EXPORT_REGEX =
-  /^export\s+(const|default|function)\s+(?<identifier>[\w$_]+)/g;
+  /^export\s+(?<qualifier>const|default|function)\s+(?<identifier>[\w$_]+)/gm;
 
 /**
  * Extract the name of the exported reference and strip the export keyword(s) from the source
  * @param source BOS Component source
  */
 export const extractExport = (source: string) => {
-  const [match, ...matches] = [...source.matchAll(EXPORT_REGEX)];
-  if (matches.length) {
-    throw new Error(`Multiple exports not permitted: ${matches.join(', ')}`);
-  }
+  const matches = [...source.matchAll(EXPORT_REGEX)];
 
-  if (!match?.groups?.identifier) {
-    return { exported: null, source };
-  }
+  return matches.reduce(
+    (exported, match) => {
+      if (!exported.hasExport) {
+        const { identifier, qualifier } = match.groups as {
+          identifier: string;
+          qualifier: string;
+        };
+        if (qualifier === 'default') {
+          if (!identifier) {
+            exported.source = exported.source
+              .replace(
+                /export\s+default\s+function\s*\(/,
+                'function BWEComponent('
+              )
+              .replace(/export\s+default\s+\(/, 'const BWEComponent = (');
+          } else {
+            exported.exportedReference = identifier;
+          }
+          exported.hasExport = true;
+        } else if (identifier === 'BWEComponent') {
+          exported.hasExport = true;
+        }
+      }
 
-  return {
-    exported: match.groups.identifier,
-    source: source.replace(
-      match[0],
-      match[0].replace(/export(\s+default)?\s+/, '')
-    ),
-  };
+      return {
+        ...exported,
+        source: exported.source.replace(
+          match[0],
+          match[0]
+            .replace(/export\s+default\s+/, '') // replace "export default"
+            .replace(/export\s+(const|function)/, '$1') // remove "export" from export statements
+        ),
+      };
+    },
+    {
+      exportedReference: '',
+      hasExport: false,
+      source,
+    }
+  );
 };

--- a/packages/compiler/src/export.ts
+++ b/packages/compiler/src/export.ts
@@ -5,23 +5,22 @@
  *  - export const BWEComponent...
  */
 const EXPORT_REGEX =
-  /^export\s+(?<qualifier>const|default|function)\s+(?<identifier>[\w$_]+)/gm;
+  /^export(?<defaultExport>\s+default)?\s+(const|function)\s+(?<identifier>[\w$_]+)?/gm;
 
 /**
  * Extract the name of the exported reference and strip the export keyword(s) from the source
  * @param source BOS Component source
  */
 export const extractExport = (source: string) => {
-  const matches = [...source.matchAll(EXPORT_REGEX)];
-
-  return matches.reduce(
+  return [...source.matchAll(EXPORT_REGEX)].reduce(
     (exported, match) => {
       if (!exported.hasExport) {
-        const { identifier, qualifier } = match.groups as {
+        const { defaultExport, identifier } = match.groups as {
+          defaultExport: string;
           identifier: string;
-          qualifier: string;
         };
-        if (qualifier === 'default') {
+
+        if (defaultExport) {
           if (!identifier) {
             exported.source = exported.source
               .replace(


### PR DESCRIPTION
This PR deprecates support for the JSX body Components in favor of JS modules which export a Component. The supported `export` statements are:
```js
export default XYZ; // any valid identifier is OK here
export function BWEComponent... // must be named BWEComponent
export const BWEComponent... // must be named BWEComponent
```

I'll hold off merging until we can coordinate updates for this breaking change.