### PR TITLE
feat: useCallback typedef

### DIFF
--- a/apps/demos/globals.d.ts
+++ b/apps/demos/globals.d.ts
@@ -1,6 +1,7 @@
-import { useState as useReactState, useEffect as useReactEffect } from 'react';
+import { useCallback as useReactCallback, useState as useReactState, useEffect as useReactEffect } from 'react';
 
 declare global {
+  const useCallback: typeof useReactCallback;
   const useState: typeof useReactState;
   const useEffect: typeof useReactEffect;
   function Component(props: {

--- a/apps/demos/src/StateAndTrust/TrustTree.tsx
+++ b/apps/demos/src/StateAndTrust/TrustTree.tsx
@@ -135,11 +135,11 @@ export function BWEComponent(props: Props) {
   ];
 
   const getRandomIcon = useCallback(
-    () => icons[Math.floor(Math.random() * icons.length)]
+    () => icons[Math.floor(Math.random() * icons.length)], []
   );
-  const updateCircle = useCallback(() => setCircle(getRandomIcon()));
-  const updateSquare = useCallback(() => setSquare(getRandomIcon()));
-  const updateTriangle = useCallback(() => setTriangle(getRandomIcon()));
+  const updateCircle = useCallback(() => setCircle(getRandomIcon()), []);
+  const updateSquare = useCallback(() => setSquare(getRandomIcon()), []);
+  const updateTriangle = useCallback(() => setTriangle(getRandomIcon()), []);
 
   return (
     <div>

--- a/packages/sandbox/src/constants.ts
+++ b/packages/sandbox/src/constants.ts
@@ -32,11 +32,13 @@ export const MONACO_EXTERNAL_LIBRARIES: MonacoExternalLibrary[] = [
   {
     resolutionPath: 'file:///globals.d.ts',
     source: `import {
+      useCallback as useReactCallback,
       useState as useReactState,
       useEffect as useReactEffect
     } from 'react';
     
     declare global {
+      const useCallback: typeof useReactCallback;
       const useState: typeof useReactState;
       const useEffect: typeof useReactEffect;
       function Component(props: {


### PR DESCRIPTION
This PR adds typings in `apps/demos` and `apps/sandbox` for `useCallback`, along with updating demos using `useCallback` to specify dependencies.