### PR TITLE
feat: restore option to show container boundaries

### DIFF
--- a/apps/demos/src/LandingPage.tsx
+++ b/apps/demos/src/LandingPage.tsx
@@ -1,9 +1,9 @@
 export function BWEComponent() {
-  const [isDebug, setIsDebug] = useState<boolean>(true);
-  const [showMonitor, setShowMonitor] = useState<boolean>(true);
+  const [showContainerBoundaries, setShowContainerBoundaries] =
+    useState<boolean>(true);
 
   const buildUrl = (componentPath) => {
-    return `/${componentPath}?isDebug=${isDebug}&showMonitor=${showMonitor}`;
+    return `/${componentPath}?showContainerBoundaries=${showContainerBoundaries}`;
   };
 
   return (
@@ -51,24 +51,13 @@ export function BWEComponent() {
                 type="checkbox"
                 value=""
                 id="flexCheckDefault"
-                checked={isDebug}
-                onChange={() => setIsDebug(!isDebug)}
+                checked={showContainerBoundaries}
+                onChange={() =>
+                  setShowContainerBoundaries(!showContainerBoundaries)
+                }
               />
               <label className="form-check-label" htmlFor="flexCheckDefault">
-                Enable debug mode
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                value=""
-                id="flexCheckChecked"
-                checked={showMonitor}
-                onChange={() => setShowMonitor(!showMonitor)}
-              />
-              <label className="form-check-label" htmlFor="flexCheckChecked">
-                Display Component monitor
+                Show Container Boundaries
               </label>
             </div>
             <ul className="icon-list">

--- a/apps/web/pages/[[...root]].tsx
+++ b/apps/web/pages/[[...root]].tsx
@@ -13,6 +13,9 @@ export default function Root() {
   const router = useRouter();
   const { query } = router;
 
+  // TODO update parameter name/source
+  const isDebug = query.isDebug === 'true';
+
   const rootComponentPath = Array.isArray(query.root)
     ? query.root.join('/')
     : undefined;
@@ -23,6 +26,9 @@ export default function Root() {
 
   const { components, error } = useWebEngine({
     config: {
+      debug: {
+        showContainerBoundaries: isDebug,
+      },
       flags,
       preactVersion: PREACT_VERSION,
       hooks: {
@@ -42,7 +48,7 @@ export default function Root() {
   }, [router, router.isReady, query.root]);
 
   return (
-    <div className="App">
+    <div className={`App ${isDebug ? 'bwe-debug' : ''}`}>
       {rootComponentPath && (
         <>
           {error && <div className="error">{error}</div>}

--- a/apps/web/pages/[[...root]].tsx
+++ b/apps/web/pages/[[...root]].tsx
@@ -14,7 +14,7 @@ export default function Root() {
   const { query } = router;
 
   // TODO update parameter name/source
-  const isDebug = query.isDebug === 'true';
+  const showContainerBoundaries = query.showContainerBoundaries === 'true';
 
   const rootComponentPath = Array.isArray(query.root)
     ? query.root.join('/')
@@ -27,7 +27,7 @@ export default function Root() {
   const { components, error } = useWebEngine({
     config: {
       debug: {
-        showContainerBoundaries: isDebug,
+        showContainerBoundaries,
       },
       flags,
       preactVersion: PREACT_VERSION,
@@ -48,7 +48,7 @@ export default function Root() {
   }, [router, router.isReady, query.root]);
 
   return (
-    <div className={`App ${isDebug ? 'bwe-debug' : ''}`}>
+    <div className={`App ${showContainerBoundaries ? 'bwe-debug' : ''}`}>
       {rootComponentPath && (
         <>
           {error && <div className="error">{error}</div>}

--- a/packages/application/src/handlers.ts
+++ b/packages/application/src/handlers.ts
@@ -1,4 +1,5 @@
 import type { ComponentTrust } from '@bos-web-engine/common';
+import React from 'react';
 
 import { sendMessage } from './container';
 import { createChildElements, createElement } from './react';
@@ -62,9 +63,11 @@ interface ChildComponent {
 
 export function onRender({
   data,
+  debug,
   mountElement,
   isComponentLoaded,
   loadComponent,
+  getContainerRenderCount,
   onMessageSent,
 }: RenderHandlerParams) {
   /* a component has been rendered and is ready to be updated in the outer window */
@@ -78,7 +81,18 @@ export function onRender({
     onMessageSent,
   });
   const element = createElement({
-    children: [componentChildren].flat(),
+    children: [
+      ...(debug?.showContainerBoundaries
+        ? [
+            React.createElement('div', { className: 'dom-label' }, [
+              `[${
+                componentId.split('##')[0].split('/')[1]
+              } (${getContainerRenderCount(componentId)})]`,
+            ]),
+          ]
+        : []),
+      ...[componentChildren].flat(),
+    ],
     id: componentId,
     props,
     type: node.type,

--- a/packages/application/src/hooks/useWebEngine.ts
+++ b/packages/application/src/hooks/useWebEngine.ts
@@ -44,7 +44,7 @@ export function useWebEngine({
     useState(false);
   const [nonce, setNonce] = useState('');
 
-  const { flags, hooks, preactVersion } = config;
+  const { debug, flags, hooks, preactVersion } = config;
 
   const domRoots: MutableRefObject<{ [key: string]: ReactDOM.Root }> = useRef(
     {}
@@ -102,12 +102,12 @@ export function useWebEngine({
     });
   }, []);
 
-  // const getComponentRenderCount = useCallback(
-  //   (componentId: string) => {
-  //     return components?.[componentId]?.renderCount;
-  //   },
-  //   [components]
-  // );
+  const getComponentRenderCount = useCallback(
+    (componentId: string) => {
+      return components?.[componentId]?.renderCount;
+    },
+    [components]
+  );
 
   const mountElement = useCallback(
     ({
@@ -166,6 +166,7 @@ export function useWebEngine({
           case 'component.render': {
             onRender({
               data,
+              debug,
               mountElement: ({ componentId, element }) => {
                 renderComponent(componentId);
                 mountElement({ componentId, element, id: data.node.props?.id });
@@ -173,6 +174,8 @@ export function useWebEngine({
               loadComponent: (component) =>
                 loadComponent(component.componentId, component),
               isComponentLoaded: (c: string) => !!components[c],
+              getContainerRenderCount: (containerId: string) =>
+                getComponentRenderCount(containerId),
               onMessageSent,
             });
             break;

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -37,6 +37,7 @@ export interface ComponentMetrics {
 
 export interface RenderHandlerParams {
   data: ComponentRender;
+  debug?: WebEngineDebug;
   mountElement: ({
     componentId,
     element,
@@ -46,6 +47,7 @@ export interface RenderHandlerParams {
   }) => void;
   isComponentLoaded(componentId: string): boolean;
   loadComponent(component: ComponentInstance): void;
+  getContainerRenderCount(containerId: string): number;
   onMessageSent: OnMessageSentCallback;
 }
 
@@ -102,12 +104,17 @@ export interface UseWebEngineParams {
 export type WebEngineLocalComponents =
   CompilerSetLocalComponentAction['components'];
 
+export interface WebEngineDebug {
+  showContainerBoundaries?: boolean;
+}
+
 export interface WebEngineHooks {
   containerSourceCompiled?: (response: ComponentCompilerResponse) => void;
   messageReceived?: (message: BWEMessage) => void;
 }
 
 export interface WebEngineConfiguration {
+  debug?: WebEngineDebug;
   flags?: WebEngineFlags;
   hooks?: WebEngineHooks;
   preactVersion: string;


### PR DESCRIPTION
This PR restores the functionality for rendering CSS borders to delineate the DOM trees rendered by individual containers. The landing page Component has been updated, and the URL parameter name has been changed to reflect the end behavior. The configuration could also be moved to a flag if that makes more sense than a query parameter.

Marking this as a draft for now since there is an issue where trusted Components will erroneously display a label when a subset of the DOM is rerendered. This is based on the now-faulty assumption that there is a 1:1 between containers and DOM roots, which was broken when the Preact integration was fixed to re-render only changed subsets of the DOM tree.

Addresses part of #175 (monitor should probably just mimic the `Code` tab)