### PR TITLE
fix: trusted IDs

### DIFF
--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -53,9 +53,14 @@ export function parseChildComponents(
         const propsMatch = expression.match(/\s+props:\s*/);
 
         if (!propsMatch?.index) {
+          const referencedExpression = expression.replace(
+            /Component,\s+\{/,
+            `${componentName}, { __bweMeta: { parentMeta: props.__bweMeta, `
+          );
+
           return componentSource.replaceAll(
             expression,
-            expression.replace(/Component/, componentName)
+            `${referencedExpression.slice(0, -1)}})`
           );
         }
 
@@ -77,9 +82,17 @@ export function parseChildComponents(
           .slice(openPropsBracketIndex + 1, closePropsBracketIndex - 1)
           .trim();
 
+        const expressionWithoutProps =
+          expression.slice(0, propsMatch.index) +
+          expression.slice(closePropsBracketIndex);
+
+        const bosComponentPropsString = expressionWithoutProps
+          .slice(expression.indexOf('{') + 1, -3)
+          .trim();
+
         return componentSource.replaceAll(
           expression,
-          `createElement(${componentName}, { __bweMeta: { parentMeta: props.__bweMeta }, ${propsString} })`
+          `createElement(${componentName}, { __bweMeta: { parentMeta: props.__bweMeta, ${bosComponentPropsString} }, ${propsString} })`
         );
       },
     };

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -1,4 +1,8 @@
-import type { WebEngineMeta } from '@bos-web-engine/common';
+import type {
+  ComponentTrust,
+  Props,
+  WebEngineMeta,
+} from '@bos-web-engine/common';
 import type { ComponentChildren, ComponentType, VNode } from 'preact';
 
 import type {
@@ -25,11 +29,13 @@ export const buildSafeProxy: BuildSafeProxyCallback = ({
   );
 };
 
-interface BOSComponentProps {
-  id: string;
-  src: string;
-  __bweMeta: WebEngineMeta;
-}
+type BOSComponentProps = Props & {
+  __bweMeta: WebEngineMeta & {
+    id: string;
+    src: string;
+    trust?: ComponentTrust;
+  };
+};
 
 type BWEComponentNode = VNode<BOSComponentProps>;
 
@@ -91,10 +97,8 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
     node: BWEComponentNode,
     children: ComponentChildren
   ): PlaceholderNode => {
-    const { id, src, __bweMeta } = node.props;
-    const childComponentId = [src, id, __bweMeta?.parentMeta?.componentId].join(
-      '##'
-    );
+    const { id, src, parentMeta } = node.props.__bweMeta;
+    const childComponentId = [src, id, parentMeta?.componentId].join('##');
 
     return {
       type: 'div',


### PR DESCRIPTION
This PR fixes an inconsistency in how `props` are treated on trusted Components. Going forward, Component-level props (e.g. `src`, `id`) will be accessible to trusted children as metadata, i.e. `props.__bweMeta.src`.

Fixes #211 