### PR TITLE
feat: CSS compilation

### DIFF
--- a/packages/application/src/components/ComponentTree.tsx
+++ b/packages/application/src/components/ComponentTree.tsx
@@ -16,6 +16,7 @@ export default function ComponentTree({
         <div
           id={getAppDomId(rootComponentPath)}
           className="container-child"
+          data-component-src={rootComponentPath}
         ></div>
         <div className="iframes">
           {Object.entries(components)

--- a/packages/application/src/hooks/useComponents.ts
+++ b/packages/application/src/hooks/useComponents.ts
@@ -95,6 +95,7 @@ export function useComponents({
         const {
           componentId,
           componentSource,
+          containerStyles,
           error: loadError,
           importedModules,
         } = data;
@@ -102,6 +103,16 @@ export function useComponents({
         if (loadError) {
           setError(loadError.message);
           return;
+        }
+
+        if (containerStyles) {
+          const targetStylesheet = document.styleSheets[1];
+          const css = new CSSStyleSheet();
+          css.replaceSync(containerStyles);
+
+          for (let i = 0; i < css.cssRules.length; i++) {
+            targetStylesheet.insertRule(css.cssRules[i].cssText);
+          }
         }
 
         hooks?.containerSourceCompiled?.(data);

--- a/packages/common/src/types/render.ts
+++ b/packages/common/src/types/render.ts
@@ -13,4 +13,5 @@ export interface Props extends KeyValuePair {
   children?: any[];
   className?: string;
   id?: string;
+  'data-component-src'?: string;
 }

--- a/packages/compiler/src/source.ts
+++ b/packages/compiler/src/source.ts
@@ -2,6 +2,7 @@ import { JsonRpcProvider } from '@near-js/providers';
 import type { CodeResult } from '@near-js/types';
 
 import type { SocialComponentsByAuthor } from './types';
+import { BOSModuleEntry } from './types';
 
 const encodeComponentKeyArgs = (componentPaths: string[]) => {
   const bytes = new TextEncoder().encode(
@@ -35,12 +36,24 @@ export function fetchComponentSources(
         (sources, [author, { widget: component }]) => {
           Object.entries(component).forEach(
             ([componentKey, componentSource]) => {
-              sources[`${author}/${componentKey}`] = componentSource;
+              if (typeof componentSource === 'string') {
+                sources[`${author}/${componentKey}`] = {
+                  component: componentSource,
+                };
+              } else if (componentSource) {
+                const { '': source, css } = componentSource;
+                sources[`${author}/${componentKey}`] = {
+                  component: source,
+                  css,
+                };
+              } else {
+                console.error(`Invalid component source: ${componentSource}`);
+              }
             }
           );
           return sources;
         },
-        {} as { [key: string]: any }
+        {} as { [key: string]: BOSModuleEntry }
       );
     });
 }

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -17,9 +17,7 @@ export interface CompilerInitAction {
 export interface CompilerSetLocalComponentAction {
   action: 'set-local-components';
   components: {
-    [path: string]: {
-      source: string;
-    };
+    [path: string]: BOSModuleEntry;
   };
   rootComponentPath: string;
 }
@@ -27,6 +25,7 @@ export interface CompilerSetLocalComponentAction {
 export interface ComponentCompilerResponse {
   componentId: string;
   componentSource: string;
+  containerStyles: string;
   rawSource: string;
   componentPath: string;
   error?: Error;
@@ -48,6 +47,7 @@ export interface TranspiledComponentLookupParams {
 export type ComponentMap = Map<string, ComponentTreeNode>;
 
 export interface ComponentTreeNode {
+  css?: string;
   imports: ModuleImport[];
   transpiled: string;
 }
@@ -55,6 +55,7 @@ export interface ComponentTreeNode {
 export interface ParseComponentTreeParams {
   components: ComponentMap;
   componentSource: string;
+  componentStyles?: string;
   componentPath: string;
   isComponentPathTrusted?: (path: string) => boolean;
   isRoot: boolean;
@@ -85,8 +86,18 @@ export interface ImportExpression {
   reference?: string;
 }
 
+export interface BOSModuleEntry {
+  component: string;
+  css?: string;
+}
+
+interface ComponentEntry {
+  '': string;
+  css: string;
+}
+
 interface SocialComponent {
-  widget: { [name: string]: string };
+  widget: { [name: string]: string | ComponentEntry };
 }
 
 export type SocialComponentsByAuthor = { [author: string]: SocialComponent };

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -345,6 +345,7 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
               componentId,
             },
             className: 'container-child',
+            'data-component-src': src,
           },
         },
       };

--- a/packages/sandbox/src/components/Preview.tsx
+++ b/packages/sandbox/src/components/Preview.tsx
@@ -65,7 +65,7 @@ export function Preview() {
       const path = `${ACCOUNT_ID}/${componentName}`;
 
       editorComponents[path] = {
-        source: file.source,
+        component: file.source,
       };
     });
 


### PR DESCRIPTION
This PR parses a new `css` key on responses from Components sources (sandbox, `bos-loader`, or on-chain), aggregating stylesheets at the container level. Component-level CSS is wrapped by selectors to encapsulate styles, restricting them to be applied to instances of that component within that container.

There is not a convenient way of uploading CSS at the moment so I have created #221 as a way to test locally.