### PR TITLE
feat: import enhancements

### DIFF
--- a/apps/demos/globals.d.ts
+++ b/apps/demos/globals.d.ts
@@ -1,9 +1,6 @@
-import { useCallback as useReactCallback, useState as useReactState, useEffect as useReactEffect } from 'react';
+import type { JSX } from 'react';
 
 declare global {
-  const useCallback: typeof useReactCallback;
-  const useState: typeof useReactState;
-  const useEffect: typeof useReactEffect;
   function Component(props: {
     src: string;
     props?: Record<any, any>;

--- a/apps/demos/src/LandingPage.tsx
+++ b/apps/demos/src/LandingPage.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 export function BWEComponent() {
   const [showContainerBoundaries, setShowContainerBoundaries] =
     useState<boolean>(true);

--- a/apps/demos/src/Posts/Account.tsx
+++ b/apps/demos/src/Posts/Account.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 interface Profile {
   description?: string;
   name?: string;

--- a/apps/demos/src/Posts/Feed.tsx
+++ b/apps/demos/src/Posts/Feed.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 export function BWEComponent() {
   const GRAPHQL_ENDPOINT = 'https://near-queryapi.api.pagoda.co';
 

--- a/apps/demos/src/Posts/Marked.tsx
+++ b/apps/demos/src/Posts/Marked.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 export function BWEComponent() {
   const [Markdown, setMarkdown] = useState(null);
   const importMarkdown = async () => {

--- a/apps/demos/src/Posts/Marked.tsx
+++ b/apps/demos/src/Posts/Marked.tsx
@@ -1,22 +1,5 @@
-import { useEffect, useState } from 'react';
+import Markdown from 'marked-react@2.0.0';
 
 export function BWEComponent() {
-  const [Markdown, setMarkdown] = useState(null);
-  const importMarkdown = async () => {
-    try {
-      const markdownDyn = await import(
-        'https://esm.sh/marked-react@2.0.0?alias=react:preact/compat'
-      );
-      console.log('markdown imported');
-      setMarkdown(markdownDyn);
-    } catch (err) {
-      console.log('markdown import error', err);
-    }
-  };
-
-  useEffect(() => {
-    importMarkdown();
-  }, []);
-
-  return Markdown ? <Markdown>{'# hello world'}</Markdown> : <div>Loading</div>;
+  return <Markdown>{'# hello world'}</Markdown>;
 }

--- a/apps/demos/src/StateAndTrust/TrustTree.tsx
+++ b/apps/demos/src/StateAndTrust/TrustTree.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useState } from 'react';
+
 interface Props {
   title: string;
 }
@@ -135,7 +137,8 @@ export function BWEComponent(props: Props) {
   ];
 
   const getRandomIcon = useCallback(
-    () => icons[Math.floor(Math.random() * icons.length)], []
+    () => icons[Math.floor(Math.random() * icons.length)],
+    []
   );
   const updateCircle = useCallback(() => setCircle(getRandomIcon()), []);
   const updateSquare = useCallback(() => setSquare(getRandomIcon()), []);

--- a/architecture.md
+++ b/architecture.md
@@ -66,8 +66,3 @@ While functions cannot be provided as arguments directly, references to callback
 BOS Components to invoke functions on `props` with function arguments.
 - Inter-container callbacks are inherently asynchronous, for which a Promise-based interface is provided to abstract away
 the underlying event-based communication.
-
-This inherent asymmetry presents a challenge to BOS Component developers, who must now contend with two different return
-types entirely contingent on how their Component is consumed. To unify this interface, the current implementation provides
-an optional `useComponentCallback` hook returning a higher-order function to be invoked instead of invoking the callback
-directly.

--- a/packages/application/src/components/SandboxedIframe.tsx
+++ b/packages/application/src/components/SandboxedIframe.tsx
@@ -38,17 +38,8 @@ function buildSandboxedComponent({
         <script type="module">
             import * as __Preact from 'preact';
 
-/******** BEGIN BOS SOURCE ********/
-/******** The root Component definition is inlined here as [function BWEComponent() {...}] ********/
-${scriptSrc}
-/******** END BOS SOURCE ********/
-
-          const initContainer = ${initContainer.toString()};
-
           // placeholder function to bind Component references in BOS Component source
           function Component() {}
-
-          let props;
 
           // TODO bind/replace React.Fragment during transpilation and remove this shim
           if (typeof React === 'undefined') {
@@ -56,52 +47,56 @@ ${scriptSrc}
           }
           React.Fragment = __Preact.Fragment ;
 
-          const {
-            commit,
-            processEvent,
-            props: containerProps,
-          } = initContainer({
-            containerMethods: {
-              buildEventHandler: ${buildEventHandler.toString()},
-              buildRequest: ${buildRequest.toString()},
-              buildSafeProxy: ${buildSafeProxy.toString()},
-              composeMessagingMethods: ${composeMessagingMethods.toString()},
-              composeRenderMethods: ${composeRenderMethods.toString()},
-              composeSerializationMethods: ${composeSerializationMethods.toString()},
-              invokeCallback: ${invokeCallback.toString()},
-              invokeComponentCallback: ${invokeComponentCallback.toString()},
-            },
-            context: {
-              BWEComponent,
-              Component,
-              componentId: '${id}',
-              componentPropsJson: ${componentPropsJson},
-              Fragment: __Preact.Fragment,
-              parentContainerId: '${parentContainerId}',
-              trust: ${JSON.stringify(trust)},
-              updateContainerProps: (updateProps) => {
-                const originalProps = props;
-                // if nothing has changed, the same [props] object will be returned
-                props = updateProps(props);
-                if (props !== originalProps) {
-                  __Preact.render(createElement(BWEComponent, props), document.body);
-                }
+/******** BEGIN BOS SOURCE ********/
+/******** The root Component definition is inlined here as [function BWEComponent() {...}] ********/
+${scriptSrc}
+/******** END BOS SOURCE ********/
+
+          (function () {
+            const {
+              commit,
+              processEvent,
+              props,
+            } = (${initContainer.toString()})({
+              containerMethods: {
+                buildEventHandler: ${buildEventHandler.toString()},
+                buildRequest: ${buildRequest.toString()},
+                buildSafeProxy: ${buildSafeProxy.toString()},
+                composeMessagingMethods: ${composeMessagingMethods.toString()},
+                composeRenderMethods: ${composeRenderMethods.toString()},
+                composeSerializationMethods: ${composeSerializationMethods.toString()},
+                invokeCallback: ${invokeCallback.toString()},
+                invokeComponentCallback: ${invokeComponentCallback.toString()},
               },
-            },
-          });
+              context: {
+                BWEComponent,
+                Component,
+                componentId: '${id}',
+                componentPropsJson: ${componentPropsJson},
+                Fragment: __Preact.Fragment,
+                parentContainerId: '${parentContainerId}',
+                trust: ${JSON.stringify(trust)},
+                updateContainerProps: (updateProps) => {
+                  const originalProps = props;
+                  // if nothing has changed, the same [props] object will be returned
+                  props = updateProps(props);
+                  if (props !== originalProps) {
+                    __Preact.render(createElement(BWEComponent, props), document.body);
+                  }
+                },
+              },
+            });
 
-          // intialize props
-          props = containerProps;
-
-          const oldCommit = __Preact.options.__c;
-          __Preact.options.__c = (vnode, commitQueue) => {
-            commit(vnode);
-            oldCommit?.(vnode, commitQueue);
-          };
-
-          window.addEventListener('message', processEvent);
-
-          __Preact.render(__Preact.createElement(BWEComponent, props), document.body);
+            const oldCommit = __Preact.options.__c;
+            __Preact.options.__c = (vnode, commitQueue) => {
+              commit(vnode);
+              oldCommit?.(vnode, commitQueue);
+            };
+  
+            window.addEventListener('message', processEvent);
+  
+            __Preact.render(__Preact.createElement(BWEComponent, props), document.body);
+          }());
         </script>
       </body>
     </html>

--- a/packages/application/src/components/SandboxedIframe.tsx
+++ b/packages/application/src/components/SandboxedIframe.tsx
@@ -36,10 +36,7 @@ function buildSandboxedComponent({
           }
         </script>
         <script type="module">
-          import * as Preact from 'preact';
-          import { useCallback, useEffect, useState } from 'preact/hooks';
-
-          const { createElement } = Preact;
+            import * as __Preact from 'preact';
 
 /******** BEGIN BOS SOURCE ********/
 /******** The root Component definition is inlined here as [function BWEComponent() {...}] ********/
@@ -65,7 +62,7 @@ ${scriptSrc}
           let props;
 
           // TODO map reference during transpilation
-          const React = { Fragment: Preact.Fragment };
+          const React = { Fragment: __Preact.Fragment };
 
           const {
             commit,
@@ -87,7 +84,7 @@ ${scriptSrc}
               Component,
               componentId: '${id}',
               componentPropsJson: ${componentPropsJson},
-              Fragment: Preact.Fragment,
+              Fragment: __Preact.Fragment,
               parentContainerId: '${parentContainerId}',
               trust: ${JSON.stringify(trust)},
               updateContainerProps: (updateProps) => {
@@ -95,7 +92,7 @@ ${scriptSrc}
                 // if nothing has changed, the same [props] object will be returned
                 props = updateProps(props);
                 if (props !== originalProps) {
-                  Preact.render(createElement(BWEComponent, props), document.body);
+                  __Preact.render(createElement(BWEComponent, props), document.body);
                 }
               },
             },
@@ -104,15 +101,15 @@ ${scriptSrc}
           // intialize props
           props = containerProps;
 
-          const oldCommit = Preact.options.__c;
-          Preact.options.__c = (vnode, commitQueue) => {
+          const oldCommit = __Preact.options.__c;
+          __Preact.options.__c = (vnode, commitQueue) => {
             commit(vnode);
             oldCommit?.(vnode, commitQueue);
           };
 
           window.addEventListener('message', processEvent);
 
-          Preact.render(createElement(BWEComponent, props), document.body);
+          __Preact.render(__Preact.createElement(BWEComponent, props), document.body);
         </script>
       </body>
     </html>

--- a/packages/application/src/components/SandboxedIframe.tsx
+++ b/packages/application/src/components/SandboxedIframe.tsx
@@ -50,8 +50,11 @@ ${scriptSrc}
 
           let props;
 
-          // TODO map reference during transpilation
-          const React = { Fragment: __Preact.Fragment };
+          // TODO bind/replace React.Fragment during transpilation and remove this shim
+          if (typeof React === 'undefined') {
+            window.React = {};
+          }
+          React.Fragment = __Preact.Fragment ;
 
           const {
             commit,

--- a/packages/application/src/components/SandboxedIframe.tsx
+++ b/packages/application/src/components/SandboxedIframe.tsx
@@ -48,17 +48,6 @@ ${scriptSrc}
           // placeholder function to bind Component references in BOS Component source
           function Component() {}
 
-          function useComponentCallback(cb, args) {
-            const [value, setValue] = useState(undefined);
-            useEffect(() => {
-              (async () => {
-                setValue(await cb(args));
-              })();
-            }, []);
-        
-            return () => value;
-          }
-
           let props;
 
           // TODO map reference during transpilation

--- a/packages/application/src/hooks/useComponents.ts
+++ b/packages/application/src/hooks/useComponents.ts
@@ -115,7 +115,8 @@ export function useComponents({
         importedModules.set('react-dom', `${preactImportBasePath}/compat`);
 
         for (const moduleName of importedModules.keys()) {
-          if (moduleName.startsWith('preact/') && moduleName.split('/')[1]) {
+          const [lib, subpath] = moduleName.split('/');
+          if (subpath && ['preact', 'react-dom'].includes(lib)) {
             importedModules.delete(moduleName);
           }
         }

--- a/packages/application/src/hooks/useComponents.ts
+++ b/packages/application/src/hooks/useComponents.ts
@@ -108,11 +108,17 @@ export function useComponents({
 
         // set the Preact import maps
         // TODO find a better place for this
-        importedModules.set('preact', `https://esm.sh/preact@${preactVersion}`);
-        importedModules.set(
-          'preact/',
-          `https://esm.sh/preact@${preactVersion}/`
-        );
+        const preactImportBasePath = `https://esm.sh/preact@${preactVersion}`;
+        importedModules.set('preact', preactImportBasePath);
+        importedModules.set('preact/', `${preactImportBasePath}/`);
+        importedModules.set('react', `${preactImportBasePath}/compat`);
+        importedModules.set('react-dom', `${preactImportBasePath}/compat`);
+
+        for (const moduleName of importedModules.keys()) {
+          if (moduleName.startsWith('preact/') && moduleName.split('/')[1]) {
+            importedModules.delete(moduleName);
+          }
+        }
 
         const component = {
           ...components[componentId],

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -7,6 +7,28 @@ type ImportMixed = ImportModule & {
   reference: string;
 };
 
+const stripLeadingComment = (source: string) => {
+  if (!source) {
+    return source;
+  }
+
+  if (source.startsWith('//')) {
+    return source.slice(source.indexOf('\n') + 1).trim();
+  }
+
+  if (source.startsWith('/*')) {
+    let i = 2;
+    while (i < source.length) {
+      if (source.slice(i, i + 2) === '*/') {
+        return source.slice(i + 2).trim();
+      }
+      i++;
+    }
+  }
+
+  return source;
+};
+
 // valid combinations of default, namespace, and destructured imports
 const MIXED_IMPORT_REGEX =
   /^import\s+(?<reference>[\w$]+)?\s*,?(\s*\*\s+as\s+(?<namespace>[\w-]+))?(\s*{\s*(?<destructured>[\w\s*\/,$-]+)})?\s+from\s+["'](?<modulePath>[\w@\/.:?&=-]+)["'];?\s*/gi;
@@ -18,7 +40,7 @@ const SIDE_EFFECT_IMPORT_REGEX =
  * @param source BOS Component source code
  */
 export const extractImportStatements = (source: string) => {
-  let src = source.trim();
+  let src = stripLeadingComment(source.trim());
 
   const imports: ModuleImport[] = [];
   while (src.startsWith('import')) {
@@ -92,6 +114,8 @@ export const extractImportStatements = (source: string) => {
         break;
       }
     }
+
+    src = stripLeadingComment(src.trim());
   }
 
   return {

--- a/packages/compiler/src/transpile.ts
+++ b/packages/compiler/src/transpile.ts
@@ -12,7 +12,7 @@ export function transpileSource(source: string): {
     plugins: [
       [
         Babel.availablePlugins['transform-react-jsx'],
-        { pragma: 'createElement' },
+        { pragma: '__Preact.createElement' },
       ],
     ],
     filename: 'component.tsx', // name is not important, just the extension

--- a/packages/sandbox/src/constants.ts
+++ b/packages/sandbox/src/constants.ts
@@ -31,16 +31,9 @@ export const MONACO_EXTERNAL_LIBRARIES: MonacoExternalLibrary[] = [
   },
   {
     resolutionPath: 'file:///globals.d.ts',
-    source: `import {
-      useCallback as useReactCallback,
-      useState as useReactState,
-      useEffect as useReactEffect
-    } from 'react';
+    source: `import { JSX } from 'react';
     
     declare global {
-      const useCallback: typeof useReactCallback;
-      const useState: typeof useReactState;
-      const useEffect: typeof useReactEffect;
       function Component(props: {
         src: string;
         props?: Record<any, any>;
@@ -70,6 +63,7 @@ export const DEFAULT_FILES: SandboxFiles = {
   make a visible code change, and then come back to HelloWorld.tsx
   to see your changes reflected in the <Component /> reference.
 */
+import { useState } from 'react';
 
 export function BWEComponent() {
   const [count, setCount] = useState(0);


### PR DESCRIPTION
This PR implements imports of `react`, `preact`, and `react-dom` (all using Preact) and fixes bugs around namespace imports. With these dependencies now importable, I went ahead and cleaned up the global variables in the container context.

After merging this, references to React hooks must be imported:
```js
import { useCallback } from 'react';
```
alternatively:
```js
import { useCallback } from 'preact/hooks';
```

Fixes #225 