### PR TITLE
fix: invalid props references

### DIFF
--- a/packages/application/src/components/SandboxedIframe.tsx
+++ b/packages/application/src/components/SandboxedIframe.tsx
@@ -53,7 +53,7 @@ ${scriptSrc}
 /******** END BOS SOURCE ********/
 
           (function () {
-            const {
+            let {
               commit,
               processEvent,
               props,
@@ -81,7 +81,7 @@ ${scriptSrc}
                   // if nothing has changed, the same [props] object will be returned
                   props = updateProps(props);
                   if (props !== originalProps) {
-                    __Preact.render(createElement(BWEComponent, props), document.body);
+                    __Preact.render(__Preact.createElement(BWEComponent, props), document.body);
                   }
                 },
               },

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -55,7 +55,7 @@ export function parseChildComponents(
         if (!propsMatch?.index) {
           const referencedExpression = expression.replace(
             /Component,\s+\{/,
-            `${componentName}, { __bweMeta: { parentMeta: props.__bweMeta, `
+            `${componentName}, { __bweMeta: { parentMeta: typeof props === 'undefined' ? null : props?.__bweMeta, `
           );
 
           return componentSource.replaceAll(
@@ -92,7 +92,7 @@ export function parseChildComponents(
 
         return componentSource.replaceAll(
           expression,
-          `createElement(${componentName}, { __bweMeta: { parentMeta: props.__bweMeta, ${bosComponentPropsString} }, ${propsString} })`
+          `createElement(${componentName}, { __bweMeta: { parentMeta: typeof props === 'undefined' ? null : props?.__bweMeta, ${bosComponentPropsString} }, ${propsString} })`
         );
       },
     };


### PR DESCRIPTION
This PR fixes `props` references for root Components without a `props` argument. Also fixes bad references in the container update logic.

Both were bugs leftover from the purging of global references #227 