### PR TITLE
feat: useCompiler hook

### DIFF
--- a/packages/application/src/hooks/useCompiler.ts
+++ b/packages/application/src/hooks/useCompiler.ts
@@ -1,0 +1,37 @@
+import { BOSModule } from '@bos-web-engine/common';
+import { useEffect, useState } from 'react';
+
+import type { CompilerWorker, WebEngineConfiguration } from '../types';
+
+/**
+ * Provides an interface for managing containers
+ * @param config parameters to be applied to the entire Component tree
+ * @param rootComponentPath Component path for the root Component
+ */
+export function useCompiler({
+  config,
+  localComponents,
+}: {
+  config: WebEngineConfiguration;
+  localComponents?: { [path: string]: BOSModule };
+}) {
+  const [compiler, setCompiler] = useState<CompilerWorker | null>(null);
+
+  useEffect(() => {
+    if (!compiler) {
+      const worker = new Worker(
+        new URL('../workers/compiler.js', import.meta.url)
+      );
+
+      worker.postMessage({
+        action: 'init',
+        localComponents,
+        localFetchUrl: config.flags?.bosLoaderUrl,
+        preactVersion: config.preactVersion,
+      });
+      setCompiler(worker);
+    }
+  }, [config.flags?.bosLoaderUrl, config.preactVersion, localComponents]);
+
+  return compiler;
+}

--- a/packages/application/src/hooks/useCompiler.ts
+++ b/packages/application/src/hooks/useCompiler.ts
@@ -19,19 +19,29 @@ export function useCompiler({
 
   useEffect(() => {
     if (!compiler) {
-      const worker = new Worker(
-        new URL('../workers/compiler.js', import.meta.url)
+      setCompiler(
+        new Worker(new URL('../workers/compiler.js', import.meta.url))
       );
-
-      worker.postMessage({
-        action: 'init',
-        localComponents,
-        localFetchUrl: config.flags?.bosLoaderUrl,
-        preactVersion: config.preactVersion,
-      });
-      setCompiler(worker);
     }
-  }, [config.flags?.bosLoaderUrl, config.preactVersion, localComponents]);
+  }, [compiler]);
+
+  useEffect(() => {
+    if (!compiler) {
+      return;
+    }
+
+    compiler.postMessage({
+      action: 'init',
+      localComponents,
+      localFetchUrl: config.flags?.bosLoaderUrl,
+      preactVersion: config.preactVersion,
+    });
+  }, [
+    compiler,
+    config.flags?.bosLoaderUrl,
+    config.preactVersion,
+    localComponents,
+  ]);
 
   return compiler;
 }

--- a/packages/application/src/hooks/useWebEngine.ts
+++ b/packages/application/src/hooks/useWebEngine.ts
@@ -1,3 +1,4 @@
+import { useCompiler } from './useCompiler';
 import { useComponents } from './useComponents';
 import { useComponentTree } from './useComponentTree';
 import type { UseWebEngineParams } from '../types';
@@ -6,10 +7,13 @@ export function useWebEngine({
   config,
   rootComponentPath,
 }: UseWebEngineParams) {
-  const { addComponent, compiler, components, error, getComponentRenderCount, hooks } = useComponents({
-    config,
-    rootComponentPath,
-  });
+  const compiler = useCompiler({ config });
+  const { addComponent, components, error, getComponentRenderCount, hooks } =
+    useComponents({
+      compiler,
+      config,
+      rootComponentPath,
+    });
 
   useComponentTree({
     addComponent,

--- a/packages/application/src/hooks/useWebEngineSandbox.ts
+++ b/packages/application/src/hooks/useWebEngineSandbox.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { useCompiler } from './useCompiler';
 import { useComponents } from './useComponents';
 import { useComponentTree } from './useComponentTree';
 import type { UseWebEngineSandboxParams } from '../types';
@@ -10,15 +11,17 @@ export function useWebEngineSandbox({
   rootComponentPath,
 }: UseWebEngineSandboxParams) {
   const [nonce, setNonce] = useState('');
+
+  const compiler = useCompiler({ config, localComponents });
   const {
     addComponent,
-    compiler,
     components,
     error,
     getComponentRenderCount,
     hooks,
     setComponents,
   } = useComponents({
+    compiler,
     config,
     rootComponentPath,
   });
@@ -39,11 +42,16 @@ export function useWebEngineSandbox({
     setNonce(`${rootComponentPath}:${Date.now().toString()}`);
 
     compiler?.postMessage({
-      action: 'set-local-components',
-      components: localComponents,
-      rootComponentPath,
+      action: 'init',
+      localComponents,
+      preactVersion: config.preactVersion,
     });
-  }, [compiler, localComponents, rootComponentPath]);
+
+    compiler?.postMessage({
+      action: 'execute',
+      componentId: rootComponentPath,
+    });
+  }, [compiler, domRoots, localComponents, rootComponentPath]);
 
   return {
     components,

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -6,7 +6,7 @@ import type {
   MessagePayload,
 } from '@bos-web-engine/common';
 import type {
-  CompilerSetLocalComponentAction,
+  ComponentCompilerRequest,
   ComponentCompilerResponse,
 } from '@bos-web-engine/compiler';
 import type { DOMElement } from 'react';
@@ -95,7 +95,12 @@ export interface CreateChildElementParams {
   parentId: string;
 }
 
+export interface CompilerWorker extends Omit<Worker, 'postMessage'> {
+  postMessage(compilerRequest: ComponentCompilerRequest): void;
+}
+
 export interface UseWebEngineParams {
+  compiler: CompilerWorker | null;
   config: WebEngineConfiguration;
   rootComponentPath?: string;
 }
@@ -103,9 +108,6 @@ export interface UseWebEngineParams {
 export interface UseWebEngineSandboxParams extends UseWebEngineParams {
   localComponents?: WebEngineLocalComponents;
 }
-
-export type WebEngineLocalComponents =
-  CompilerSetLocalComponentAction['components'];
 
 export interface WebEngineDebug {
   showContainerBoundaries?: boolean;

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  BOSModule,
   ComponentCallbackInvocation,
   ComponentCallbackResponse,
   ComponentRender,

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -101,13 +101,16 @@ export interface CompilerWorker extends Omit<Worker, 'postMessage'> {
 }
 
 export interface UseWebEngineParams {
-  compiler: CompilerWorker | null;
   config: WebEngineConfiguration;
   rootComponentPath?: string;
 }
 
+export interface UseComponentsParams extends UseWebEngineParams {
+  compiler: CompilerWorker | null;
+}
+
 export interface UseWebEngineSandboxParams extends UseWebEngineParams {
-  localComponents?: WebEngineLocalComponents;
+  localComponents?: { [path: string]: BOSModule };
 }
 
 export interface WebEngineDebug {

--- a/packages/application/src/workers/compiler.ts
+++ b/packages/application/src/workers/compiler.ts
@@ -23,9 +23,6 @@ self.onmessage = ({
         self.postMessage({ error: e });
       });
       break;
-    case 'set-local-components':
-      compiler.setLocalComponents(compileRequest);
-      break;
     default:
       break;
   }

--- a/packages/common/src/types/compilation.ts
+++ b/packages/common/src/types/compilation.ts
@@ -1,0 +1,4 @@
+export interface BOSModule {
+  component: string;
+  css?: string;
+}

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './compilation';
 export * from './helpers';
 export * from './messaging';
 export * from './render';

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -19,7 +19,6 @@ import type {
   BOSModuleEntry,
   CompilerExecuteAction,
   CompilerInitAction,
-  CompilerSetLocalComponentAction,
   ComponentCompilerParams,
   ComponentTreeNode,
   ModuleImport,
@@ -54,9 +53,16 @@ export class ComponentCompiler {
     });
   }
 
-  init({ localFetchUrl, preactVersion }: CompilerInitAction) {
+  init({ localComponents, localFetchUrl, preactVersion }: CompilerInitAction) {
     this.localFetchUrl = localFetchUrl;
     this.preactVersion = preactVersion;
+
+    this.bosSourceCache.clear();
+    this.compiledSourceCache.clear();
+
+    Object.entries(localComponents || {}).forEach(([path, component]) => {
+      this.bosSourceCache.set(path, Promise.resolve(component));
+    });
   }
 
   /**
@@ -452,24 +458,5 @@ ${styleSheet}
       const { code: component } = componentSource;
       this.bosSourceCache.set(componentPath, Promise.resolve({ component }));
     }
-  }
-
-  setLocalComponents({
-    components,
-    rootComponentPath,
-  }: CompilerSetLocalComponentAction) {
-    // TODO: Implement separated cache layers
-
-    this.bosSourceCache.clear();
-    this.compiledSourceCache.clear();
-
-    Object.entries(components).forEach(([path, component]) => {
-      this.bosSourceCache.set(path, Promise.resolve(component));
-    });
-
-    this.compileComponent({
-      action: 'execute',
-      componentId: rootComponentPath,
-    });
   }
 }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -1,4 +1,4 @@
-import { TrustMode } from '@bos-web-engine/common';
+import { BOSModule, TrustMode } from '@bos-web-engine/common';
 import { SocialDb } from '@bos-web-engine/social-db-api';
 
 import {
@@ -16,7 +16,6 @@ import { parseChildComponents, ParsedChildComponent } from './parser';
 import { fetchComponentSources } from './source';
 import { transpileSource } from './transpile';
 import type {
-  BOSModuleEntry,
   CompilerExecuteAction,
   CompilerInitAction,
   ComponentCompilerParams,
@@ -35,7 +34,7 @@ interface BuildComponentSourceParams {
 }
 
 export class ComponentCompiler {
-  private bosSourceCache: Map<string, Promise<BOSModuleEntry | null>>;
+  private bosSourceCache: Map<string, Promise<BOSModule | null>>;
   private compiledSourceCache: Map<string, string | null>;
   private readonly sendWorkerMessage: SendMessageCallback;
   private hasFetchedLocal: boolean = false;
@@ -44,7 +43,7 @@ export class ComponentCompiler {
   private social: SocialDb;
 
   constructor({ sendMessage }: ComponentCompilerParams) {
-    this.bosSourceCache = new Map<string, Promise<BOSModuleEntry>>();
+    this.bosSourceCache = new Map<string, Promise<BOSModule>>();
     this.compiledSourceCache = new Map<string, string>();
     this.sendWorkerMessage = sendMessage;
     this.social = new SocialDb({
@@ -146,7 +145,7 @@ export class ComponentCompiler {
       });
     }
 
-    const componentSources = new Map<string, Promise<BOSModuleEntry | null>>();
+    const componentSources = new Map<string, Promise<BOSModule | null>>();
     componentPaths.forEach((componentPath) => {
       const componentSource = this.bosSourceCache.get(componentPath);
       if (componentSource) {
@@ -448,7 +447,7 @@ ${styleSheet}
     }
 
     const data = (await res.json()) as {
-      components: Record<string, BOSModuleEntry>;
+      components: Record<string, BOSModule>;
     };
     for (const [componentPath, componentSource] of Object.entries(
       data.components

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,7 +1,6 @@
 export type {
   ComponentCompilerRequest,
   ComponentCompilerResponse,
-  CompilerSetLocalComponentAction,
 } from './types';
 
 export { ComponentCompiler } from './compiler';

--- a/packages/compiler/src/source.ts
+++ b/packages/compiler/src/source.ts
@@ -1,9 +1,10 @@
+import type { BOSModule } from '@bos-web-engine/common';
 import {
   SOCIAL_COMPONENT_NAMESPACE,
   SocialDb,
 } from '@bos-web-engine/social-db-api';
 
-import { BOSModuleEntry, ComponentEntry } from './types';
+import { ComponentEntry } from './types';
 
 export async function fetchComponentSources(
   social: SocialDb,
@@ -49,6 +50,6 @@ export async function fetchComponentSources(
       });
       return sources;
     },
-    {} as { [key: string]: BOSModuleEntry }
+    {} as { [key: string]: BOSModule }
   );
 }

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -1,3 +1,5 @@
+import type { BOSModule } from '@bos-web-engine/common';
+
 export type ComponentCompilerRequest =
   | CompilerExecuteAction
   | CompilerInitAction;
@@ -7,7 +9,7 @@ export interface CompilerExecuteAction {
   componentId: string;
 }
 
-export type LocalComponentMap = { [path: string]: BOSModuleEntry };
+export type LocalComponentMap = { [path: string]: BOSModule };
 
 export interface CompilerInitAction {
   action: 'init';
@@ -78,11 +80,6 @@ export interface ImportExpression {
   isDestructured?: boolean;
   isNamespace?: boolean;
   reference?: string;
-}
-
-export interface BOSModuleEntry {
-  component: string;
-  css?: string;
 }
 
 export interface ComponentEntry {

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -1,25 +1,19 @@
 export type ComponentCompilerRequest =
   | CompilerExecuteAction
-  | CompilerInitAction
-  | CompilerSetLocalComponentAction;
+  | CompilerInitAction;
 
 export interface CompilerExecuteAction {
   action: 'execute';
   componentId: string;
 }
 
+export type LocalComponentMap = { [path: string]: BOSModuleEntry };
+
 export interface CompilerInitAction {
   action: 'init';
+  localComponents?: LocalComponentMap;
   localFetchUrl?: string;
   preactVersion: string;
-}
-
-export interface CompilerSetLocalComponentAction {
-  action: 'set-local-components';
-  components: {
-    [path: string]: BOSModuleEntry;
-  };
-  rootComponentPath: string;
 }
 
 export interface ComponentCompilerResponse {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -46,6 +46,7 @@
     "zustand": "^4.4.3"
   },
   "devDependencies": {
+    "@bos-web-engine/common": "workspace:*",
     "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-typescript": "^8.3.4",

--- a/packages/sandbox/src/components/Preview.tsx
+++ b/packages/sandbox/src/components/Preview.tsx
@@ -1,8 +1,8 @@
-import type { WebEngineLocalComponents } from '@bos-web-engine/application';
 import {
   ComponentTree,
   useWebEngineSandbox,
 } from '@bos-web-engine/application';
+import type { BOSModule } from '@bos-web-engine/common';
 import { Dropdown } from '@bos-web-engine/ui';
 import { useWallet } from '@bos-web-engine/wallet-selector-control';
 import { CaretDown, Eye } from '@phosphor-icons/react';
@@ -17,6 +17,8 @@ import {
 import { useDebouncedValue } from '../hooks/useDebounced';
 import { useSandboxStore } from '../hooks/useSandboxStore';
 import { convertFilePathToComponentName } from '../utils';
+
+type WebEngineLocalComponents = { [path: string]: BOSModule };
 
 export function Preview() {
   const { account } = useWallet();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3(@types/react@18.2.45)(react@18.2.0)
     devDependencies:
+      '@bos-web-engine/common':
+        specifier: workspace:*
+        version: link:../common
       '@rollup/plugin-commonjs':
         specifier: ^22.0.1
         version: 22.0.2(rollup@2.79.1)


### PR DESCRIPTION
This PR introduces the `useCompiler` hook, refactoring it out of `useComponents` for direct use within the `useWebEngine*` hooks. This fixes some mis-mapped behavior from the refactor of these methods that needed to be fixed as a prerequisite for #219

In addition, the sandbox-specific call to the compiler worker has been removed. Its behavior has been rolled into the existing `init` call, which is now made whenever any of the compiler parameters (Preact version, sandbox IDE Components, etc.) are updated. Exposing the compiler interface to the `useWebEngine*` hooks while parameterizing their divergent behavior is a net benefit here, and does some of the ground work necessary for a future web worker responsible for managing BWE Component source fetching/caching.