### PR TITLE
feat: Component imports

### DIFF
--- a/apps/demos/src/StateAndTrust/Root.tsx
+++ b/apps/demos/src/StateAndTrust/Root.tsx
@@ -1,4 +1,6 @@
-export function BWEComponent() {
+import TrustTree from './TrustTree';
+
+export default function BWEComponent() {
   return (
     <>
       <div className="row">
@@ -10,17 +12,15 @@ export function BWEComponent() {
       </div>
       <div className="row">
         <div className="col">
-          <Component
+          <TrustTree
             id="trusted"
-            src="bwe-demos.near/StateAndTrust.TrustTree"
             trust={{ mode: 'trusted-author' }}
             props={{ title: 'State across Trusted Components' }}
           />
         </div>
         <div className="col">
-          <Component
+          <TrustTree
             id="sandboxed"
-            src="bwe-demos.near/StateAndTrust.TrustTree"
             props={{ title: 'State within Sandboxed Components' }}
           />
         </div>

--- a/apps/demos/src/StateAndTrust/SetParent.tsx
+++ b/apps/demos/src/StateAndTrust/SetParent.tsx
@@ -1,3 +1,5 @@
+import ShapeSet from './ShapeSet';
+
 interface Props {
   circle: string;
   id: string;
@@ -8,7 +10,7 @@ interface Props {
   updateTriangle: () => {};
 }
 
-export function BWEComponent(props: Props) {
+export default function BWEComponent(props: Props) {
   const {
     circle,
     square,
@@ -21,9 +23,8 @@ export function BWEComponent(props: Props) {
 
   return (
     <div>
-      <Component
+      <ShapeSet
         id={id}
-        src="bwe-demos.near/StateAndTrust.ShapeSet"
         props={{
           circle,
           square,

--- a/apps/demos/src/StateAndTrust/Shape/Circle.tsx
+++ b/apps/demos/src/StateAndTrust/Shape/Circle.tsx
@@ -6,7 +6,7 @@ interface Props {
   radius: number;
 }
 
-export function BWEComponent(props: Props) {
+export default function BWEComponent(props: Props) {
   const diameterPx = `${props.radius * 2}px`;
   return (
     <div

--- a/apps/demos/src/StateAndTrust/Shape/Square.tsx
+++ b/apps/demos/src/StateAndTrust/Shape/Square.tsx
@@ -6,7 +6,7 @@ interface Props {
   onClick: () => {};
 }
 
-export function BWEComponent(props: Props) {
+export default function BWEComponent(props: Props) {
   const lengthPx = `${props.length}px`;
   return (
     <div

--- a/apps/demos/src/StateAndTrust/Shape/Triangle.tsx
+++ b/apps/demos/src/StateAndTrust/Shape/Triangle.tsx
@@ -6,7 +6,7 @@ interface Props {
   onClick: () => {};
 }
 
-export function BWEComponent(props: Props) {
+export default function BWEComponent(props: Props) {
   return (
     <div
       onClick={props.onClick}

--- a/apps/demos/src/StateAndTrust/ShapeSet.tsx
+++ b/apps/demos/src/StateAndTrust/ShapeSet.tsx
@@ -1,3 +1,7 @@
+import Circle from './Shape/Circle';
+import Square from './Shape/Square';
+import Triangle from './Shape/Triangle';
+
 interface Props {
   circle: string;
   square: string;
@@ -7,13 +11,12 @@ interface Props {
   updateTriangle: () => {};
 }
 
-export function BWEComponent(props: Props) {
+export default function BWEComponent(props: Props) {
   return (
     <div className="row" style={{ padding: '8px 4px' }}>
       <div className="col">
-        <Component
+        <Circle
           id="circle"
-          src="bwe-demos.near/StateAndTrust.Shape.Circle"
           props={{
             color: '#C1200B',
             iconColor: 'white',
@@ -24,9 +27,8 @@ export function BWEComponent(props: Props) {
         />
       </div>
       <div className="col">
-        <Component
+        <Square
           id="square"
-          src="bwe-demos.near/StateAndTrust.Shape.Square"
           props={{
             color: '#4A825A',
             iconColor: 'white',
@@ -37,8 +39,8 @@ export function BWEComponent(props: Props) {
         />
       </div>
       <div className="col">
-        <Component
-          src="bwe-demos.near/StateAndTrust.Shape.Triangle"
+        <Triangle
+          id="triangle"
           props={{
             color: '#0A81D1',
             iconColor: 'white',

--- a/apps/demos/src/StateAndTrust/TrustTree.tsx
+++ b/apps/demos/src/StateAndTrust/TrustTree.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useState } from 'react';
 
+import SetParent from './SetParent';
+import ShapeSet from './ShapeSet';
+
 interface Props {
   title: string;
 }
 
-export function BWEComponent(props: Props) {
+export default function BWEComponent(props: Props) {
   const [circle, setCircle] = useState('circle');
   const [triangle, setTriangle] = useState('triangle');
   const [square, setSquare] = useState('square');
@@ -150,9 +153,8 @@ export function BWEComponent(props: Props) {
         <p>{props.title}</p>
       </div>
       <div className="col">
-        <Component
+        <ShapeSet
           id="root-shapes"
-          src="bwe-demos.near/StateAndTrust.ShapeSet"
           props={{
             circle,
             square,
@@ -162,9 +164,8 @@ export function BWEComponent(props: Props) {
             updateTriangle,
           }}
         />
-        <Component
+        <SetParent
           id="parent-shapes"
-          src="bwe-demos.near/StateAndTrust.SetParent"
           props={{
             id: 'parent-shapes',
             circle,

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -1,3 +1,44 @@
+import { TrustMode } from '@bos-web-engine/common';
+
+import { extractExport } from './export';
+import {
+  buildComponentImportStatements,
+  extractImportStatements,
+} from './import';
+import { parseChildComponents, ParsedChildComponent } from './parser';
+import type { ModuleImport } from './types';
+
+const COMPONENT_IMPORT_PLACEHOLDER = '/* COMPONENT_IMPORT_PLACEHOLDER */';
+
+/**
+ * Determine whether a child Component is trusted and can be inlined within the current container
+ * @param trustMode explicit trust mode provided for this child render
+ * @param path child Component's path
+ * @param isComponentPathTrusted flag indicating whether the child is implicitly trusted by virtue of being under a trusted root
+ */
+export function isChildComponentTrusted(
+  { trustMode, path }: ParsedChildComponent,
+  isComponentPathTrusted?: (p: string) => boolean
+) {
+  // child is explicitly trusted by parent or constitutes a new trusted root
+  if (trustMode === TrustMode.Trusted || trustMode === TrustMode.TrustAuthor) {
+    return true;
+  }
+
+  // child is explicitly sandboxed
+  if (trustMode === TrustMode.Sandboxed) {
+    return false;
+  }
+
+  // if the Component is not explicitly trusted or sandboxed, use the parent's
+  // predicate to determine whether the Component should be trusted
+  if (isComponentPathTrusted) {
+    return isComponentPathTrusted(path);
+  }
+
+  return false;
+}
+
 /**
  * Returns the name to be used for the Component function
  * @param componentPath
@@ -12,30 +53,132 @@ export function buildComponentFunctionName(componentPath?: string) {
 }
 
 interface BuildComponentFunctionParams {
-  componentImports: string[];
   componentPath: string;
   componentSource: string;
   exportedReference: string | null;
   isRoot: boolean;
+  packageImports: string[];
 }
 
-export function buildComponentFunction({
-  componentImports,
+interface BuildComponentSourceParams {
+  componentPath: string;
+  isRoot: boolean;
+  transpiledComponentSource: string;
+}
+
+/**
+ * Build the transpiled source of a BOS Component along with its imports
+ * @param componentPath path to the BOS Component
+ * @param componentSource source code of the BOS Component
+ * @param isRoot flag indicating whether this is the root Component of a container
+ */
+export function buildComponentSource({
+  componentPath,
+  isRoot,
+  transpiledComponentSource,
+}: BuildComponentSourceParams): {
+  // componentImports: ModuleImport[];
+  childComponents: ParsedChildComponent[];
+  packageImports: ModuleImport[];
+  source: string;
+} {
+  // separate out import statements from Component source
+  const { imports, source: importlessSource } = extractImportStatements(
+    transpiledComponentSource
+  );
+
+  // get the exported reference's name and remove the export keyword(s) from Component source
+  // TODO halt parsing of the current Component if no export is found
+  const {
+    exportedReference,
+    hasExport,
+    source: cleanComponentSource,
+  } = extractExport(importlessSource);
+
+  if (!hasExport) {
+    throw new Error(
+      `Could not parse Component ${componentPath}: missing valid Component export`
+    );
+  }
+
+  const packageImports = imports
+    .filter((moduleImport) => !moduleImport.isRelative)
+    .map((moduleImport) => buildComponentImportStatements(moduleImport))
+    .flat()
+    .filter((statement) => !!statement) as string[];
+
+  // assign a known alias to the exported Component
+  const source = buildComponentFunction({
+    componentPath,
+    componentSource: cleanComponentSource,
+    packageImports,
+    exportedReference,
+    isRoot,
+  });
+
+  // enumerate the set of Components imported by the current Component
+  const childComponents = parseChildComponents({
+    componentPath,
+    transpiledComponent: source,
+    componentImports: imports.filter(({ isRelative }) => isRelative),
+  });
+
+  const importedComponentDefinitions = childComponents
+    .filter(
+      (child) =>
+        !isChildComponentTrusted(child) && child.componentImportReference
+    )
+    .map((child) =>
+      buildSandboxedChildComponent({
+        componentName: child.componentImportReference!,
+        componentPath: child.path,
+      })
+    )
+    .join('\n');
+
+  return {
+    childComponents,
+    packageImports: imports.filter(({ isRelative }) => !isRelative),
+    source: source.replace(
+      COMPONENT_IMPORT_PLACEHOLDER,
+      importedComponentDefinitions
+    ),
+  };
+}
+
+function buildComponentFunction({
   componentPath,
   componentSource,
   exportedReference,
   isRoot,
+  packageImports,
 }: BuildComponentFunctionParams) {
   const functionName = buildComponentFunctionName(isRoot ? '' : componentPath);
-  const importAssignments = componentImports.join('\n');
+  const importAssignments = packageImports.join('\n');
   const commentHeader = `${componentPath} ${isRoot ? '(root)' : ''}`;
 
   return `
     /************************* ${commentHeader} *************************/
     const ${functionName} = (() => {
       ${importAssignments}
+      ${COMPONENT_IMPORT_PLACEHOLDER}
       ${componentSource}
       return ${exportedReference ? exportedReference : 'BWEComponent'};
     })();
+  `;
+}
+
+export function buildSandboxedChildComponent({
+  componentName,
+  componentPath,
+}: {
+  componentName: string;
+  componentPath: string;
+}) {
+  return `
+    function ${componentName}(childProps) {
+      const { props, ...componentProps } = childProps;
+      return __Preact.createElement(Component, { ...componentProps, props, src: "${componentPath}" });
+    }
   `;
 }

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -102,7 +102,7 @@ export function buildComponentSource({
   }
 
   const packageImports = imports
-    .filter((moduleImport) => !moduleImport.isRelative)
+    .filter((moduleImport) => !moduleImport.isBweModule)
     .map((moduleImport) => buildComponentImportStatements(moduleImport))
     .flat()
     .filter((statement) => !!statement) as string[];
@@ -118,9 +118,9 @@ export function buildComponentSource({
 
   // enumerate the set of Components imported by the current Component
   const childComponents = parseChildComponents({
+    bweModuleImports: imports.filter(({ isBweModule }) => isBweModule),
     componentPath,
     transpiledComponent: source,
-    componentImports: imports.filter(({ isRelative }) => isRelative),
   });
 
   const importedComponentDefinitions = childComponents
@@ -138,7 +138,7 @@ export function buildComponentSource({
 
   return {
     childComponents,
-    packageImports: imports.filter(({ isRelative }) => !isRelative),
+    packageImports: imports.filter(({ isBweModule }) => !isBweModule),
     source: source.replace(
       COMPONENT_IMPORT_PLACEHOLDER,
       importedComponentDefinitions

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -31,7 +31,7 @@ const stripLeadingComment = (source: string) => {
 
 // valid combinations of default, namespace, and destructured imports
 const MIXED_IMPORT_REGEX =
-  /^import\s+(?<reference>[\w$]+)?\s*,?(\s*\*\s+as\s+(?<namespace>[\w-]+))?(\s*{\s*(?<destructured>[\w\s*\/,$-]+)})?\s+from\s+["'](?<modulePath>[\w@\/.:?&=-]+)["'];?\s*/gi;
+  /^import\s+(?<reference>[\w$]+)?\s*,?(\s*\*\s+as\s+(?<namespace>[\w-]+))?(\s*{\s*(?<destructured>[\w\s*\/,$-]+)})?\s+from\s+["'`](?<modulePath>[\w@\/.:?&=-]+)["'`];?\s*/gi;
 const SIDE_EFFECT_IMPORT_REGEX =
   /^import\s+["'](?<modulePath>[\w@\/.:?&=-]+)["'];?\s*/gi;
 
@@ -50,6 +50,9 @@ export const extractImportStatements = (source: string) => {
         mixedMatch.groups as ImportMixed;
 
       const moduleName = extractModuleName(modulePath);
+      const isRelative = !!modulePath?.match(
+        /^\.?\.\/(\.\.\/)*[a-z_$][\w\/]*$/gi
+      );
 
       if (destructured) {
         const destructuredReferences = destructured
@@ -76,6 +79,7 @@ export const extractImportStatements = (source: string) => {
             ...(reference ? [{ isDefault: true, reference }] : []),
             ...destructuredReferences,
           ],
+          isRelative,
         });
       } else if (namespace) {
         imports.push({
@@ -85,12 +89,14 @@ export const extractImportStatements = (source: string) => {
             ...(reference ? [{ isDefault: true, reference }] : []),
             { isNamespace: true, alias: namespace },
           ],
+          isRelative,
         });
       } else {
         imports.push({
           moduleName,
           modulePath,
           imports: [{ isDefault: true, reference }],
+          isRelative,
         });
       }
 

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -1,100 +1,197 @@
-function parseComponentRenders(transpiledComponent: string) {
-  const functionOffset = 'createElement'.length;
-  const componentRegex =
-    /createElement\(Component,\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/[\w.-]+))["|']/gi;
-  return [...transpiledComponent.matchAll(componentRegex)].map((match) => {
-    const openParenIndex = match.index! + functionOffset;
-    let parenCount = 1;
-    let idx = openParenIndex + 1;
-    while (parenCount > 0) {
-      const char = transpiledComponent[idx++];
-      if (char === '(') {
-        parenCount++;
-      } else if (char === ')') {
-        parenCount--;
-      }
-    }
+import { ModuleImport } from './types';
 
-    return {
-      expression: transpiledComponent.substring(
-        openParenIndex - functionOffset,
-        idx
-      ),
-      source: match.groups?.src || '',
-      index: match.index!,
-    };
-  });
+function deriveComponentPath(
+  componentPath: string,
+  componentImport: ModuleImport
+) {
+  const [author, component] = componentPath.split('/');
+  const importPathComponents = componentImport.modulePath.split('/');
+  const pathComponents = component.split('.');
+
+  return `${author}/${[
+    ...pathComponents.slice(
+      0,
+      pathComponents.length -
+        importPathComponents.filter((p) => p.startsWith('.')).length
+    ),
+    ...importPathComponents.slice(1),
+  ].join('.')}`;
+}
+
+function parseComponentRenderMatch(
+  match: RegExpMatchArray,
+  transpiledComponent: string
+) {
+  const functionOffset = 'createElement'.length;
+  const openParenIndex = match.index! + functionOffset;
+  let parenCount = 1;
+  let idx = openParenIndex + 1;
+  while (parenCount > 0) {
+    const char = transpiledComponent[idx++];
+    if (char === '(') {
+      parenCount++;
+    } else if (char === ')') {
+      parenCount--;
+    }
+  }
+
+  return {
+    componentPath: match.groups?.src || '',
+    expression: transpiledComponent.substring(
+      openParenIndex - functionOffset,
+      idx
+    ),
+    index: match.index!,
+  };
+}
+
+function getComponentImportReference(moduleImport: ModuleImport) {
+  // TODO support non-default imports, i.e. other than `import C from './C'`
+  return moduleImport.imports[0].reference;
+}
+
+interface ComponentRenderMatch {
+  /* the matched render expression in the form of: createElement(ComponentName, ...) */
+  expression: string;
+  /* starting index of the matched expression within the Component source */
+  index: number;
+  /* metadata on the matched Component's import statement (n/a for <Component src="..." /> references) */
+  moduleImport?: ModuleImport;
+  /* matched Component path */
+  componentPath: string;
+}
+
+function matchDynamicComponents(
+  transpiledComponent: string
+): ComponentRenderMatch[] {
+  return [
+    ...transpiledComponent.matchAll(
+      /createElement\(Component,\s*\{(?:[\w\W]*?)(?:\s*src:\s*["|'](?<src>((([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+)\/[\w.-]+))["|']/gi
+    ),
+  ].map((match) => parseComponentRenderMatch(match, transpiledComponent));
+}
+
+function matchImportedComponents(
+  componentPath: string,
+  transpiledComponent: string,
+  moduleImport: ModuleImport
+): ComponentRenderMatch[] {
+  return [
+    ...transpiledComponent.matchAll(
+      new RegExp(
+        `createElement\\(${getComponentImportReference(moduleImport)},`,
+        'ig'
+      )
+    ),
+  ].map((match) => ({
+    ...parseComponentRenderMatch(match, transpiledComponent),
+    componentPath: deriveComponentPath(componentPath, moduleImport),
+    moduleImport,
+  }));
+}
+
+function parseComponentRenders(
+  componentPath: string,
+  transpiledComponent: string,
+  moduleImports: ModuleImport[]
+) {
+  return [
+    ...matchDynamicComponents(transpiledComponent),
+    ...moduleImports
+      .map((moduleImport) =>
+        matchImportedComponents(
+          componentPath,
+          transpiledComponent,
+          moduleImport
+        )
+      )
+      .flat(),
+  ];
 }
 
 export interface ParsedChildComponent {
+  componentImportReference?: string;
   path: string;
   transform: (componentSource: string, componentName: string) => string;
   index: number;
   trustMode: string;
 }
 
-export function parseChildComponents(
-  transpiledComponent: string
-): ParsedChildComponent[] {
-  const componentRenders = parseComponentRenders(transpiledComponent);
+interface ChildComponents {
+  componentPath: string;
+  transpiledComponent: string;
+  componentImports: ModuleImport[];
+}
+
+export function parseChildComponents({
+  componentPath,
+  transpiledComponent,
+  componentImports,
+}: ChildComponents): ParsedChildComponent[] {
+  const componentRenders = parseComponentRenders(
+    componentPath,
+    transpiledComponent,
+    componentImports
+  );
+
   componentRenders.sort((a, b) => a.index - b.index);
-  return componentRenders.map(({ expression, index, source }) => {
-    const [trustMatch] = [
-      ...expression.matchAll(
-        /trust(?:\s*:\s*{(?:[\w\W])*?mode\s*:\s*['"](trusted-author|trusted|sandboxed))/gi
-      ),
-    ];
+  return componentRenders.map(
+    ({ expression, index, componentPath: childPath, moduleImport }) => {
+      const [trustMatch] = [
+        ...expression.matchAll(
+          /trust(?:\s*:\s*{(?:[\w\W])*?mode\s*:\s*['"](trusted-author|trusted|sandboxed))/gi
+        ),
+      ];
 
-    return {
-      index,
-      path: source,
-      trustMode: trustMatch?.[1],
-      transform: (componentSource: string, componentName: string) => {
-        const propsMatch = expression.match(/\s+props:\s*/);
+      return {
+        index,
+        componentImportReference:
+          moduleImport && getComponentImportReference(moduleImport),
+        path: childPath,
+        trustMode: trustMatch?.[1],
+        transform: (componentSource: string, componentName: string) => {
+          const propsMatch = expression.match(/\s+props:\s*/);
 
-        if (!propsMatch?.index) {
-          const referencedExpression = expression.replace(
-            /Component,\s+\{/,
-            `${componentName}, { __bweMeta: { parentMeta: typeof props === 'undefined' ? null : props?.__bweMeta, `
-          );
+          // does expression match `createElement(Component, null)`?
+          if (!propsMatch?.index) {
+            return componentSource.replaceAll(
+              expression,
+              `createElement(${componentName}, { __bweMeta: { parentMeta: typeof props === 'undefined' ? null : props?.__bweMeta } })`
+            );
+          }
+
+          const openPropsBracketIndex = propsMatch.index + propsMatch[0].length;
+          let closePropsBracketIndex = openPropsBracketIndex + 1;
+          let openBracketCount = 1;
+          while (openBracketCount) {
+            const char = expression[closePropsBracketIndex];
+            if (char === '{') {
+              openBracketCount++;
+            } else if (char === '}') {
+              openBracketCount--;
+            }
+
+            closePropsBracketIndex++;
+          }
+
+          const propsString = expression
+            .slice(openPropsBracketIndex + 1, closePropsBracketIndex - 1)
+            .trim();
+
+          const expressionWithoutProps =
+            expression.slice(0, propsMatch.index - 1) +
+            expression.slice(closePropsBracketIndex);
+
+          const bosComponentPropsString = expressionWithoutProps
+            .slice(expression.indexOf('{') + 1, -3)
+            .trim();
 
           return componentSource.replaceAll(
             expression,
-            `${referencedExpression.slice(0, -1)}})`
+            `createElement(${componentName}, { __bweMeta: { parentMeta: typeof props === 'undefined' ? null : props?.__bweMeta, ${bosComponentPropsString} }, ${propsString} })`
           );
-        }
-
-        const openPropsBracketIndex = propsMatch.index + propsMatch[0].length;
-        let closePropsBracketIndex = openPropsBracketIndex + 1;
-        let openBracketCount = 1;
-        while (openBracketCount) {
-          const char = expression[closePropsBracketIndex];
-          if (char === '{') {
-            openBracketCount++;
-          } else if (char === '}') {
-            openBracketCount--;
-          }
-
-          closePropsBracketIndex++;
-        }
-
-        const propsString = expression
-          .slice(openPropsBracketIndex + 1, closePropsBracketIndex - 1)
-          .trim();
-
-        const expressionWithoutProps =
-          expression.slice(0, propsMatch.index - 1) +
-          expression.slice(closePropsBracketIndex);
-
-        const bosComponentPropsString = expressionWithoutProps
-          .slice(expression.indexOf('{') + 1, -3)
-          .trim();
-
-        return componentSource.replaceAll(
-          expression,
-          `createElement(${componentName}, { __bweMeta: { parentMeta: typeof props === 'undefined' ? null : props?.__bweMeta, ${bosComponentPropsString} }, ${propsString} })`
-        );
-      },
-    };
-  });
+        },
+      };
+    }
+  );
 }

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -85,19 +85,27 @@ function matchImportedComponents(
     ),
   ].map((match) => ({
     ...parseComponentRenderMatch(match, transpiledComponent),
-    componentPath: deriveComponentPath(componentPath, moduleImport),
+    componentPath: moduleImport.isRelative
+      ? deriveComponentPath(componentPath, moduleImport)
+      : moduleImport.modulePath,
     moduleImport,
   }));
 }
 
-function parseComponentRenders(
-  componentPath: string,
-  transpiledComponent: string,
-  moduleImports: ModuleImport[]
-) {
+interface ParseComponentRendersParams {
+  bweModuleImports: ModuleImport[];
+  componentPath: string;
+  transpiledComponent: string;
+}
+
+function parseComponentRenders({
+  bweModuleImports,
+  componentPath,
+  transpiledComponent,
+}: ParseComponentRendersParams) {
   return [
     ...matchDynamicComponents(transpiledComponent),
-    ...moduleImports
+    ...bweModuleImports
       .map((moduleImport) =>
         matchImportedComponents(
           componentPath,
@@ -118,21 +126,21 @@ export interface ParsedChildComponent {
 }
 
 interface ChildComponents {
+  bweModuleImports: ModuleImport[];
   componentPath: string;
   transpiledComponent: string;
-  componentImports: ModuleImport[];
 }
 
 export function parseChildComponents({
+  bweModuleImports,
   componentPath,
   transpiledComponent,
-  componentImports,
 }: ChildComponents): ParsedChildComponent[] {
-  const componentRenders = parseComponentRenders(
+  const componentRenders = parseComponentRenders({
     componentPath,
     transpiledComponent,
-    componentImports
-  );
+    bweModuleImports,
+  });
 
   componentRenders.sort((a, b) => a.index - b.index);
   return componentRenders.map(

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -68,6 +68,7 @@ export interface TrustedRoot {
 // structured representation of import statement
 export interface ModuleImport {
   imports: ImportExpression[];
+  isRelative?: boolean;
   isSideEffect?: boolean;
   moduleName: string;
   modulePath: string;

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -68,6 +68,7 @@ export interface TrustedRoot {
 // structured representation of import statement
 export interface ModuleImport {
   imports: ImportExpression[];
+  isBweModule?: boolean;
   isRelative?: boolean;
   isSideEffect?: boolean;
   moduleName: string;


### PR DESCRIPTION
This PR updates the `import` syntax to support importing BWE Components statically. Relative and full imports are supported.

Components may now be referenced as:
```jsx
import Form from 'ex.near/Form'; // for an absolute reference to a Component
import Button from './Button'; // for a Component in the same folder
...
<Form id="form" props={...} />
<Button id="button" props={...} />
```

instead of
```jsx
<Component src="ex.near/Form" id="form" props={...} />
<Component src="me.near/Button" id="button" props={...} />
```

Note that the latter form (`<Component src="..." />`) is still supported after making this change.

Destructured imports are not supported with this change. Currently BWE Modules must have either a default export or an export named `BWEComponent`, which the new behavior binds using the default import syntax (`import X from ...`) **regardless of how it was exported**. I have mixed feelings about this approach, but prefer it over requiring multiple imports of the same name, e.g.
```jsx
import { BWEComponent as Message } from './Message';
import { BWEComponent as Button } from './Button';
```

Fixes #219 