### PR TITLE
fix: Component props order

### DIFF
--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -83,7 +83,7 @@ export function parseChildComponents(
           .trim();
 
         const expressionWithoutProps =
-          expression.slice(0, propsMatch.index) +
+          expression.slice(0, propsMatch.index - 1) +
           expression.slice(closePropsBracketIndex);
 
         const bosComponentPropsString = expressionWithoutProps


### PR DESCRIPTION
This PR fixes a bug with props injection at build time. When `props` is the first key specified, the parsed match expects a leading `{`. This character is not expected when the first key is not `props`, so the workaround is to move the substring index to the previous character - `{` in this case. If `props` is the first key, this now-excluded character is whitespace and the index change is a no-op.

Fixes #245 