### PR TITLE
Support Nested Fragments

### DIFF
--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -51,7 +51,6 @@ interface PlaceholderNode {
 
 interface RenderedVNode extends VNode<any> {
   __k?: RenderedVNode[];
-  __e?: Node;
 }
 
 type DispatchRenderCallback = (vnode: VNode) => void;
@@ -147,8 +146,8 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
         return renderedChildren.map((child) => {
 
           // Return the text content directly if it's a text node
-          if (child.__e instanceof Text) {
-            return child.props
+          if (typeof child.props === 'string') {
+            return child.props;
           }
 
           // For non-text nodes, parse the tree recursively

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -140,11 +140,32 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
           },
           fragmentChildren[0].__k
         );
-      }
+      } else {
+        // Handling for nested fragments or fragments with multiple children
 
-      return renderedChildren.map((child) =>
-        parseRenderedTree(child)
-      ) as VNode[];
+        // Check if all children are valid nodes (e.g., they have a type)
+        const hasValidChildren = fragmentChildren.every(child => child.type !== null);
+
+        if (hasValidChildren) {
+          // If all children are valid, directly return them without additional wrapping
+          // This preserves fragment behavior by not adding unnecessary DOM elements
+          return fragmentChildren.map(
+            child => parseRenderedTree(child, child.__k)
+          ) as VNode[];
+        } else {
+          // If there are invalid children, wrap them in a div for proper rendering
+          // This handles cases where fragments may contain text nodes or other non-component content
+          return parseRenderedTree(
+            {
+              type: 'div',
+              key: `nested-fragment-${childIndex}`,
+              props: null,
+            },
+            fragmentChildren,
+            childIndex
+          );
+        }
+      }
     }
 
     const props =


### PR DESCRIPTION
## Problem

### Overview
Nested fragments with invalid markup aren't supported. So, for example, this won't work:
```jsx
<>
  <>
    text
  </>
<>
```

But this *does* work in React. Part of the issue is that when fragments don't contain valid markup, React will just happily insert it into the DOM anyway. So this is "valid" React code 😬. 

### Technical Dive

Basically we were [crashing here](https://github.com/near/bos-web-engine/blob/835bd57d9fd4a9f88b63a4183f95d5c019555295/packages/application/src/react.ts#L80-L89) because `children` did not contain any elements. 

### Example:
Valid `children`:

![image](https://github.com/near/bos-web-engine/assets/10700079/0ab7cb2f-2056-4a34-92b0-c0f1e8f2f791)

Invalid `children`:

![image](https://github.com/near/bos-web-engine/assets/10700079/7ad0eb4a-0fae-46af-8f66-e16dae2714d3)  

Notice the null type here.

## What's New
**For Valid Children**: If a fragment's children are all valid nodes (meaning, they have a type), they're returned directly. This keeps our DOM clean and avoids adding unnecessary wrappers.

**For Invalid Children**: Sometimes, you get fragments with text nodes or similar, which aren't valid on their own. Here, I introduced a small compromise: wrapping these in a `div`. It’s a bit of a sidestep from the ideal React purity, but it gets the job done without complicating the rendering logic too much.  

## Trade-offs
I pondered a bit on this. Ideally, we'd keep everything as pure to React's principles as possible, avoiding extra DOM elements. But, the reality of supporting a wider range of use-cases with minimal complexity led me down this path. It’s a bit of a trade-off:

- **Pros**: We're now more inclusive of different fragment structures, making this a bit more forgiving and flexible.
- **Cons**: The introduction of an extra `div` for handling invalid children in fragments isn't perfectly in line with React’s minimalist DOM philosophy, although we're already wrapping the root fragment anyway 🤷‍♂️ 

## Alternatives
I’m really keen to hear your thoughts on this. I think we could probably do something with the `parser.ts` and `react.ts` to support creating elements inside a fragment without wrapping it first, although I figured this was the simplest solution. 

Another option might be to say "we don't support invalid markup". Maybe we *shouldn't* support this in the first place!

Closes #170 