### PR TITLE
feat: CSS modules

### DIFF
--- a/packages/application/src/hooks/useComponents.ts
+++ b/packages/application/src/hooks/useComponents.ts
@@ -1,14 +1,17 @@
 import type { ComponentCompilerResponse } from '@bos-web-engine/compiler';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { UseComponentsParams } from '../types';
 
 /**
  * Provides an interface for managing containers
+ * @param appendStylesheet callback to add container stylesheets to the Component tree CSS
+ * @param compiler Web Engine compiler instance
  * @param config parameters to be applied to the entire Component tree
  * @param rootComponentPath Component path for the root Component
  */
 export function useComponents({
+  appendStylesheet,
   compiler,
   config,
   rootComponentPath,
@@ -20,37 +23,6 @@ export function useComponents({
   const [rootComponentSource, setRootComponentSource] = useState<string | null>(
     null
   );
-
-  const containerStylesheet = useRef<CSSStyleSheet | null>(null);
-
-  useEffect(() => {
-    const style = document.createElement('style');
-    style.id = `bwe-styles-${Date.now()}`;
-    style.appendChild(document.createTextNode(''));
-    document.head.appendChild(style);
-
-    // @ts-expect-error StyleSheetList can be inlined despite TS complaints about [Symbol.iterator]()
-    containerStylesheet.current = [...document.styleSheets].find(
-      ({ ownerNode }) => ownerNode === style
-    );
-  }, []);
-
-  const appendStylesheet = useCallback((containerStyles: string) => {
-    const css = new CSSStyleSheet();
-    css.replaceSync(containerStyles);
-
-    // @ts-expect-error StyleSheetList can be inlined despite TS complaints about [Symbol.iterator]()
-    for (let { cssText } of css.cssRules) {
-      containerStylesheet.current!.insertRule(cssText);
-    }
-  }, []);
-
-  const resetContainerStylesheet = useCallback(() => {
-    const rulesCount = containerStylesheet.current!.cssRules.length;
-    for (let i = rulesCount - 1; i >= 0; i--) {
-      containerStylesheet.current!.deleteRule(i);
-    }
-  }, [containerStylesheet]);
 
   const addComponent = useCallback((componentId: string, component: any) => {
     setComponents((currentComponents) => ({
@@ -169,7 +141,6 @@ export function useComponents({
     error,
     hooks,
     getComponentRenderCount,
-    resetContainerStylesheet,
     setComponents,
   };
 }

--- a/packages/application/src/hooks/useCss.ts
+++ b/packages/application/src/hooks/useCss.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Manage CSS across stylesheets in the Component tree
+ */
+export function useCss() {
+  const containerStylesheet = useRef<CSSStyleSheet | null>(null);
+
+  useEffect(() => {
+    const style = document.createElement('style');
+    style.id = `bwe-styles-${Date.now()}`;
+    style.appendChild(document.createTextNode(''));
+    document.head.appendChild(style);
+
+    // @ts-expect-error StyleSheetList can be inlined despite TS complaints about [Symbol.iterator]()
+    containerStylesheet.current = [...document.styleSheets].find(
+      ({ ownerNode }) => ownerNode === style
+    );
+  }, []);
+
+  const appendStylesheet = useCallback((containerStyles: string) => {
+    const css = new CSSStyleSheet();
+    css.replaceSync(containerStyles);
+
+    // @ts-expect-error StyleSheetList can be inlined despite TS complaints about [Symbol.iterator]()
+    for (let { cssText } of css.cssRules) {
+      containerStylesheet.current!.insertRule(cssText);
+    }
+  }, []);
+
+  const resetContainerStylesheet = useCallback(() => {
+    const rulesCount = containerStylesheet.current!.cssRules.length;
+    for (let i = rulesCount - 1; i >= 0; i--) {
+      containerStylesheet.current!.deleteRule(i);
+    }
+  }, [containerStylesheet]);
+
+  return {
+    appendStylesheet,
+    resetContainerStylesheet,
+  };
+}

--- a/packages/application/src/hooks/useWebEngine.ts
+++ b/packages/application/src/hooks/useWebEngine.ts
@@ -1,15 +1,18 @@
 import { useCompiler } from './useCompiler';
 import { useComponents } from './useComponents';
 import { useComponentTree } from './useComponentTree';
+import { useCss } from './useCss';
 import type { UseWebEngineParams } from '../types';
 
 export function useWebEngine({
   config,
   rootComponentPath,
 }: UseWebEngineParams) {
+  const { appendStylesheet } = useCss();
   const compiler = useCompiler({ config });
   const { addComponent, components, error, getComponentRenderCount, hooks } =
     useComponents({
+      appendStylesheet,
       compiler,
       config,
       rootComponentPath,

--- a/packages/application/src/hooks/useWebEngineSandbox.ts
+++ b/packages/application/src/hooks/useWebEngineSandbox.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useCompiler } from './useCompiler';
 import { useComponents } from './useComponents';
 import { useComponentTree } from './useComponentTree';
+import { useCss } from './useCss';
 import type { UseWebEngineSandboxParams } from '../types';
 
 export function useWebEngineSandbox({
@@ -13,6 +14,7 @@ export function useWebEngineSandbox({
   const [nonce, setNonce] = useState('');
   const preactVersion = config.preactVersion;
 
+  const { appendStylesheet, resetContainerStylesheet } = useCss();
   const compiler = useCompiler({ config, localComponents });
   const {
     addComponent,
@@ -20,9 +22,9 @@ export function useWebEngineSandbox({
     error,
     getComponentRenderCount,
     hooks,
-    resetContainerStylesheet,
     setComponents,
   } = useComponents({
+    appendStylesheet,
     compiler,
     config,
     rootComponentPath,

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -106,6 +106,7 @@ export interface UseWebEngineParams {
 }
 
 export interface UseComponentsParams extends UseWebEngineParams {
+  appendStylesheet: (stylesheet: string) => void;
   compiler: CompilerWorker | null;
 }
 

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -139,11 +139,13 @@ export class ComponentCompiler {
     });
 
     const {
+      css: componentCss,
       childComponents,
       packageImports,
       source: componentFunctionSource,
     } = buildComponentSource({
       componentPath,
+      componentStyles,
       isRoot,
       transpiledComponentSource,
     });
@@ -177,7 +179,7 @@ export class ComponentCompiler {
 
     // add the transformed source to the returned Component tree
     components.set(componentPath, {
-      css: componentStyles,
+      css: componentCss,
       imports: packageImports,
       // replace each child [Component] reference in the target Component source
       // with the generated name of the inlined Component function definition

--- a/packages/compiler/src/component.ts
+++ b/packages/compiler/src/component.ts
@@ -106,7 +106,7 @@ export function buildComponentSource({
   }
 
   const packageImports = imports
-    .filter((moduleImport) => !moduleImport.isBweModule)
+    .filter((moduleImport) => moduleImport.isPackageImport)
     .map((moduleImport) => buildComponentImportStatements(moduleImport))
     .flat()
     .filter((statement) => !!statement) as string[];

--- a/packages/compiler/src/css.ts
+++ b/packages/compiler/src/css.ts
@@ -18,9 +18,11 @@ export function parseCssModule(css: string): ParsedCssModule {
         throw new Error('Invalid source CSS');
       }
 
-      const modifiedClassName = `${className}_${
-        crypto.randomUUID().split('-')[0]
-      }`;
+      const modifiedClassName = `${className}_${crypto
+        .randomUUID()
+        .split('-')
+        .slice(0, 2)
+        .join('')}`;
       classMap.set(className, modifiedClassName);
 
       const cssBody = css.slice(index, cssBodyClosingIndex);

--- a/packages/compiler/src/css.ts
+++ b/packages/compiler/src/css.ts
@@ -1,0 +1,37 @@
+import { getClosingCharIndex } from './text';
+import type { ParsedCssModule } from './types';
+
+export function parseCssModule(css: string): ParsedCssModule {
+  return [...css.matchAll(/^\.(\w\S+)\s*{\s*$/gim)].reduce(
+    ({ classMap, stylesheet }, classSelectorMatch) => {
+      const [classSelector, className] = classSelectorMatch;
+      const { index } = classSelectorMatch;
+
+      const cssBodyClosingIndex = getClosingCharIndex({
+        source: css,
+        openChar: '{',
+        closeChar: '}',
+        startIndex: index! + classSelector.length - 1,
+      });
+
+      if (cssBodyClosingIndex === null) {
+        throw new Error('Invalid source CSS');
+      }
+
+      const modifiedClassName = `${className}_${
+        crypto.randomUUID().split('-')[0]
+      }`;
+      classMap.set(className, modifiedClassName);
+
+      const cssBody = css.slice(index, cssBodyClosingIndex);
+      return {
+        classMap,
+        stylesheet: `
+          ${stylesheet}
+          ${cssBody.replace(className, modifiedClassName)}
+        `,
+      };
+    },
+    { classMap: new Map<string, string>(), stylesheet: '' }
+  );
+}

--- a/packages/compiler/src/text.ts
+++ b/packages/compiler/src/text.ts
@@ -1,0 +1,44 @@
+interface GetClosingIndexParams {
+  source: string;
+  openChar: string;
+  closeChar: string;
+  startIndex: number;
+}
+
+/**
+ * Find the index of the closing character
+ * @param source target string to parse
+ * @param openChar opening character (e.g. `{`)
+ * @param closeChar closing character (e.g. `}`)
+ * @param startIndex index of the first opening character within source
+ */
+export function getClosingCharIndex({
+  source,
+  openChar,
+  closeChar,
+  startIndex = 0,
+}: GetClosingIndexParams) {
+  let openCount = 0;
+  let i = startIndex;
+  if (source[i] !== openChar) {
+    throw new Error(
+      `Source must begin with "${openChar}": "${
+        source.length > 16 ? `${source.slice(0, 16)}...` : source
+      }"`
+    );
+  }
+
+  do {
+    const char = source[i++];
+    if (char === openChar) {
+      openCount++;
+    } else if (char === closeChar) {
+      openCount--;
+    } else if (char === undefined) {
+      // no closing character in source
+      return null;
+    }
+  } while (openCount > 0);
+
+  return i;
+}

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -74,6 +74,8 @@ export interface TrustedRoot {
 export interface ModuleImport {
   imports: ImportExpression[];
   isBweModule?: boolean;
+  isCssModule: boolean;
+  isPackageImport: boolean;
   isRelative?: boolean;
   isSideEffect?: boolean;
   moduleName: string;

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -42,6 +42,11 @@ export interface TranspiledComponentLookupParams {
 
 export type ComponentMap = Map<string, ComponentTreeNode>;
 
+export interface ParsedCssModule {
+  classMap: Map<string, string>;
+  stylesheet: string;
+}
+
 export interface ComponentTreeNode {
   css?: string;
   imports: ModuleImport[];


### PR DESCRIPTION
This PR adds support for basic CSS module syntax, i.e. top-level class selectors without nesting:
```css
.wrapper {
  padding: 1em;
}
```

Components may specify CSS class as strings:
```jsx
<div className="wrapper">
``` 
or via import:
```jsx
/*
  currently the path isn't validated, anything matching
  `./*.module.css` will be interpreted as a CSS module
*/
import styles from './Wrapper.module.css';
...
<div className="wrapper">
``` 

CSS module class names are transformed with UUID substrings. They are generated per Component so there is no guarantee of uniqueness, though possibility of collision is vanishingly small.

Fixes #252 