### PR TITLE
Sandbox: Updated Example Imports

### DIFF
--- a/packages/sandbox/src/components/MonacoDiff.tsx
+++ b/packages/sandbox/src/components/MonacoDiff.tsx
@@ -34,7 +34,6 @@ export function MonacoDiff() {
       </div>
 
       <DiffEditor
-        theme="vs-light"
         language={modifiedFile.language}
         original={originalFile.value}
         originalModelPath={
@@ -42,15 +41,16 @@ export function MonacoDiff() {
             ? `diff-original-${originalFile.path}`
             : 'diff-original.tsx'
         }
+        options={{
+          readOnly: true,
+        }}
         modified={modifiedFile.value}
         modifiedModelPath={
           modifiedFile.path
             ? `diff-modified-${modifiedFile.path}`
             : 'diff-modified.tsx'
         }
-        options={{
-          readOnly: true,
-        }}
+        theme="vs-light"
       />
     </div>
   );

--- a/packages/sandbox/src/components/MonacoEditor.tsx
+++ b/packages/sandbox/src/components/MonacoEditor.tsx
@@ -87,9 +87,6 @@ export function MonacoEditor() {
         model.dispose();
       }
     });
-
-    // TODO: Collect all markers (errors) between all models and show error status to user next to each file
-    // TODO: Thorough testing of sandbox after model changes
   }, [activeFilePath, files, monacoInstance]);
 
   const beforeMonacoMount: BeforeMount = (monaco) => {

--- a/packages/sandbox/src/constants.ts
+++ b/packages/sandbox/src/constants.ts
@@ -39,6 +39,12 @@ export const MONACO_EXTERNAL_LIBRARIES: MonacoExternalLibrary[] = [
     source: `import { JSX } from 'react';
     
     declare global {
+      type BWEComponent<TProps = {}> = (props: {
+        id?: string;
+        props?: TProps;
+        trust?: { mode: string };
+      }) => JSX.Element;
+
       function Component(props: {
         src: string;
         props?: Record<any, any>;
@@ -64,44 +70,32 @@ export const DEFAULT_FILES: SandboxFiles = {
   are automatically persisted in local storage. Feel free to add, 
   remove, and rename files.
   
-  If you aren't signed in, you should reference "bwe-web.near" 
-  in the src prop when creating a new component and referencing it 
-  via <Component />. For example: "bwe-web.near/MyComponent.tsx". 
-  When you sign in, these references will be replaced with your 
-  account ID.
-  
   The following code example demonstrates multi file component editing 
   capabilities. Try opening up Message.tsx from the file explorer, 
   make a visible code change, and then come back to HelloWorld.tsx
-  to see your changes reflected in the <Component /> reference.
+  to see your changes reflected in the imported component.
 */
 
 import { useState } from 'react';
+import Message from './Message';
 
-export function BWEComponent() {
+function HelloWorld() {
   const [count, setCount] = useState(0);
 
   return (
     <div className="wrapper">
       <h1>Welcome!</h1>
 
-      <Component
-        src="bwe-web.near/Message"
-        props={{ message: 'Hello world!' }}
-      /*
-        The props object for <Component /> doesn't support type 
-        safety at the moment due to the dynamic complexities 
-        involved. Implementing type safety for props is a long 
-        term goal.
-      */
-      />
+      <Message props={{ message: 'Hello world!' }} />
 
       <button type="button" onClick={() => setCount((value) => value + 1)}>
         Increase Count: {count}
       </button>
     </div>
   );
-}  
+}
+
+export default HelloWorld as BWEComponent;
 `,
   },
   'Message.tsx': {
@@ -113,18 +107,21 @@ export function BWEComponent() {
   background: var(--color-surface-3);
   border-radius: 0.5rem;
 }`,
-    source: `interface Props {
+    source: `type Props = {
   message: string;
-}
+};
 
-export function BWEComponent(props: Props) {
+function Message({ message }: Props) {
   return (
     <div className="wrapper">
       <h2>BOS Says:</h2>
-      <p>{props.message}</p>
+      <p>{message}</p>
     </div>
   );
-}`,
+}
+
+export default Message as BWEComponent<Props>;
+`,
   },
 };
 
@@ -135,15 +132,18 @@ export const NEW_COMPONENT_TEMPLATE: SandboxFile = {
   gap: 1rem;
 }
 `,
-  source: `interface Props {
+  source: `type Props = {
   message?: string;
-}
+};
 
-export function BWEComponent({ message = "Hello"}: Props) {
+function MyComponent({ message = "Hello!" }: Props) {
   return (
     <div className="wrapper">
       <p>{message}</p>
     </div>
   );
-}`,
+}
+
+export default MyComponent as BWEComponent<Props>;
+`,
 };

--- a/packages/sandbox/src/hooks/useSandboxStore.ts
+++ b/packages/sandbox/src/hooks/useSandboxStore.ts
@@ -119,6 +119,11 @@ export const useSandboxStore = create<SandboxStore>()(
             ...partialFile,
           };
 
+          if (JSON.stringify(existingFile) === JSON.stringify(updatedFile)) {
+            // If the file hasn't changed, don't update the files object
+            return {};
+          }
+
           const files = {
             ...state.files,
             [path]: {


### PR DESCRIPTION
Updating our Sandbox with our new import/export syntax. I've added a short term type fix by providing a helper type `BWEComponent` globally in the sandbox:

```tsx
type Props = {
  message: string;
  foo: number;
};

function Message({ message }: Props) {
  return (
    <div className="wrapper">
      <h2>BOS Says:</h2>
      <p>{message}</p>
    </div>
  );
}

export default Message as BWEComponent<Props>;
```

Now we have proper type safety for component `props` thanks to @andy-haynes work supporting relative imports! We'll rework this a bit once this is completed: https://github.com/near/bos-web-engine/issues/261

<img width="922" alt="Screen Shot 2024-02-09 at 2 20 02 PM" src="https://github.com/near/bos-web-engine/assets/1475067/75224cc6-7292-4c9a-9805-27d846b75656">
