### PR TITLE
fix: check for Preact nodes when serializing props

### DIFF
--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -117,10 +117,10 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
     false;
 
   function parseRenderedTree(
-    node: RenderedVNode,
-    renderedChildren?: RenderedVNode[],
+    node: RenderedVNode | null,
+    renderedChildren?: Array<RenderedVNode | null>,
     childIndex?: number
-  ): VNode | VNode[] {
+  ): VNode | null | Array<VNode | null> {
     if (!node || !renderedChildren) {
       return node;
     }
@@ -138,7 +138,7 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
             key: 'bwe-container-component',
             props: null,
           },
-          fragmentChildren[0].__k
+          fragmentChildren[0]?.__k
         );
       } else {
         // Handling for nested or non-root fragments. This will flatten non-root fragments
@@ -204,11 +204,11 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
           .flat()
           .filter((c) => !!c)
           .map((child, i) => {
-            if (child.type) {
-              return parseRenderedTree(child, child.__k, i);
+            if (child?.type) {
+              return parseRenderedTree(child, child?.__k, i);
             }
 
-            return child.props;
+            return child?.props;
           }),
       },
     };

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -143,17 +143,15 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
       } else {
         // Handling for nested or non-root fragments. This will flatten non-root fragments
 
-        return renderedChildren.map((child) => {
-
+        return fragmentChildren.map((child) => {
           // Return the text content directly if it's a text node
-          if (typeof child.props === 'string') {
+          if (typeof child?.props === 'string') {
             return child.props;
           }
 
           // For non-text nodes, parse the tree recursively
-          return parseRenderedTree(child, child.__k);
+          return parseRenderedTree(child, child?.__k);
         }) as VNode[];
-
       }
     }
 


### PR DESCRIPTION
This PR adds a missing check for Preact nodes when recursively serializing props. Since Preact nodes reference themselves, serialization triggered a stack overflow.

Fixes #265 