### PR TITLE
Sandbox: proper CSS Module import syntax

### DIFF
--- a/packages/sandbox/src/constants.ts
+++ b/packages/sandbox/src/constants.ts
@@ -39,6 +39,11 @@ export const MONACO_EXTERNAL_LIBRARIES: MonacoExternalLibrary[] = [
     source: `import { JSX } from 'react';
     
     declare global {
+      declare module '*.module.css' {
+        const classes: { [key: string]: string };
+        export default classes;
+      }
+
       type BWEComponent<TProps = {}> = (props: {
         id?: string;
         props?: TProps;
@@ -62,7 +67,8 @@ export const DEFAULT_FILES: SandboxFiles = {
   flex-direction: column;
   gap: 1rem;
   padding: 1rem;
-}`,
+}    
+  `,
     source: `/*
   Welcome to the BOS Web Engine Sandbox!
 
@@ -78,12 +84,13 @@ export const DEFAULT_FILES: SandboxFiles = {
 
 import { useState } from 'react';
 import Message from './Message';
+import s from './styles.module.css';
 
 function HelloWorld() {
   const [count, setCount] = useState(0);
 
   return (
-    <div className="wrapper">
+    <div className={s.wrapper}>
       <h1>Welcome!</h1>
 
       <Message props={{ message: 'Hello world!' }} />
@@ -104,18 +111,27 @@ export default HelloWorld as BWEComponent;
   flex-direction: column;
   gap: 0.5rem;
   padding: 1rem;
-  background: var(--color-surface-3);
+  background: var(--green-4);
+  color: var(green-1);
   border-radius: 0.5rem;
-}`,
-    source: `type Props = {
-  message: string;
+
+  h2,
+  p {
+    color: var(--green-10);
+  }
+}
+`,
+    source: `import s from './styles.module.css';
+
+type Props = {
+  message?: string;
 };
 
-function Message({ message }: Props) {
+function Message({ message = 'Default message...' }: Props) {
   return (
-    <div className="wrapper">
-      <h2>BOS Says:</h2>
-      <p>{message}</p>
+    <div className={s.wrapper}>
+      <h2 className={s.title}>BOS Says:</h2>
+      <p className={s.message}>{message}</p>
     </div>
   );
 }
@@ -130,15 +146,18 @@ export const NEW_COMPONENT_TEMPLATE: SandboxFile = {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  background: red;
 }
 `,
-  source: `type Props = {
+  source: `import s from './styles.module.css';
+
+type Props = {
   message?: string;
 };
 
 function MyComponent({ message = "Hello!" }: Props) {
   return (
-    <div className="wrapper">
+    <div className={s.wrapper}>
       <p>{message}</p>
     </div>
   );

--- a/packages/sandbox/src/constants.ts
+++ b/packages/sandbox/src/constants.ts
@@ -149,7 +149,6 @@ export const NEW_COMPONENT_TEMPLATE: SandboxFile = {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  background: red;
 }
 `,
   source: `import s from './styles.module.css';

--- a/packages/sandbox/src/constants.ts
+++ b/packages/sandbox/src/constants.ts
@@ -114,11 +114,14 @@ export default HelloWorld as BWEComponent;
   background: var(--green-4);
   color: var(green-1);
   border-radius: 0.5rem;
+}
 
-  h2,
-  p {
-    color: var(--green-10);
-  }
+.title {
+  color: var(--green-10);
+}
+
+.message {
+  color: var(--green-10);
 }
 `,
     source: `import s from './styles.module.css';

--- a/packages/ui/src/components/Button.module.css
+++ b/packages/ui/src/components/Button.module.css
@@ -25,11 +25,11 @@
   }
 
   &:hover {
-    border-color: var(--violet-6);
+    border-color: var(--color-action-primary);
   }
 
   &:focus {
-    border-color: var(--color-primary-action);
+    border-color: var(--violet-12);
     box-shadow: 0 0 0 3px var(--color-focus-outline);
   }
 


### PR DESCRIPTION
Updated the sandbox examples to use proper CSS Module import syntax since it's now supported: https://github.com/near/bos-web-engine/pull/264#issuecomment-1936428262

Anyone who's familiar with CSS Modules will immediately recognize what's going on: 

```tsx
import s from './styles.module.css';

type Props = {
  message?: string;
};

function MyComponent({ message = "Hello!" }: Props) {
  return (
    <div className={s.wrapper}>
      <p>{message}</p>
    </div>
  );
}

export default MyComponent as BWEComponent<Props>;
```