### PR TITLE
tracking page for npm compatability demos

### DIFF
--- a/apps/demos/src/LandingPage.tsx
+++ b/apps/demos/src/LandingPage.tsx
@@ -71,6 +71,11 @@ export function BWEComponent() {
               <li>
                 <a href={buildUrl('bwe-demos.near/Posts.Feed')}>Social Feed</a>
               </li>
+              <li>
+                <a href={buildUrl('bwe-demos.near/NPM.Tracker')}>
+                  NPM Compatability Tracker
+                </a>
+              </li>
             </ul>
           </div>
         </div>

--- a/apps/demos/src/NPM/Tracker.tsx
+++ b/apps/demos/src/NPM/Tracker.tsx
@@ -1,0 +1,99 @@
+interface PackageCompatibility {
+  name: string;
+  demoLink: string;
+  note?: JSX.Element | string;
+}
+
+const functionalAsExpected: PackageCompatibility[] = [
+  {
+    name: 'Lodash',
+    demoLink: '/bwe-demos.near/NPM.Lodash?showCode=true',
+  },
+  {
+    name: 'React Hook useMemo',
+    demoLink: '/bwe-demos.near/NPM.React.Hooks.UseMemo?showCode=true',
+  },
+  {
+    name: 'React Syntax Highlighter',
+    demoLink: '/bwe-demos.near/NPM.ReactSyntaxHighlighter?showCode=true',
+  },
+];
+
+const functionalWithCaveat: PackageCompatibility[] = [
+  {
+    name: 'Phosphor Icons',
+    demoLink: '/bwe-demos.near/NPM.PhosphorIcons?showCode=true',
+    note: 'Icons should use a deep import to avoid network requests for every icon simultaneously',
+  },
+];
+
+const partialSupport: PackageCompatibility[] = [];
+
+const notCompatible: PackageCompatibility[] = [
+  {
+    name: 'Zustand',
+    demoLink: '/bwe-demos.near/NPM.Zustand?showCode=true',
+    note: (
+      <span>
+        BOS Web Engine plans to support cross-component global state management:{' '}
+        <a href="https://github.com/near/bos-web-engine/issues/18">#18</a>
+      </span>
+    ),
+  },
+];
+
+const needsTesting: PackageCompatibility[] = [
+  {
+    name: 'React Hook useRef',
+    demoLink: '/bwe-demos.near/NPM.React.Hooks.UseRef?showCode=true',
+  },
+];
+
+export default function () {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>NPM Package Compatibility</h1>
+      <PackageSection
+        name="Functional as Expected"
+        packageCompats={functionalAsExpected}
+      />
+      <PackageSection
+        name="Functional w/ Caveat"
+        packageCompats={functionalWithCaveat}
+      />
+      <PackageSection name="Partial Support" packageCompats={partialSupport} />
+      <PackageSection name="Not Compatible" packageCompats={notCompatible} />
+      <PackageSection name="Needs Testing" packageCompats={needsTesting} />
+    </div>
+  );
+}
+
+function PackageSection({
+  name,
+  packageCompats,
+}: {
+  name: string;
+  packageCompats: PackageCompatibility[];
+}) {
+  if (!packageCompats.length) {
+    return <div></div>;
+  }
+  return (
+    <div>
+      <h2>{name}</h2>
+      <ul>
+        {packageCompats.map((p) => {
+          return (
+            <Component
+              trust={{ mode: 'trusted' }}
+              src="bwe-demos.near/NPM.Tracker.ComponentEntry"
+              id={p.name}
+              key={p.name}
+              props={{ ...p }}
+            />
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/demos/src/NPM/Tracker/ComponentEntry.tsx
+++ b/apps/demos/src/NPM/Tracker/ComponentEntry.tsx
@@ -1,0 +1,10 @@
+export default function ({ name, demoLink, note }) {
+  return (
+    <li>
+      <a key={name} href={demoLink}>
+        {name}
+      </a>
+      {note ? <span>: {note}</span> : ''}
+    </li>
+  );
+}


### PR DESCRIPTION
- add entry to LandingPage to get to compatability tracker
- add tracker for grouping npm demos by status
- add query param to allow code inspector to start in expanded state

![Screenshot 2024-02-12 at 1 16 02 PM](https://github.com/near/bos-web-engine/assets/24904709/7f802a23-3fbe-4c59-8e2b-d0dd49a67037)

closes #215 
