### PR TITLE
fix: strip invalid React prop keys

### DIFF
--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -153,6 +153,12 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
         (newProps, [key, value]: [string, any]) => {
           const isProxy = value?.__bweMeta?.isProxy || false;
 
+          // TODO remove invalid props keys at the source
+          //  (probably JSX transpilation)
+          if (key === 'class' || key.includes('-')) {
+            return newProps;
+          }
+
           const serializeCallback = (
             callbackName: string,
             callback: Function


### PR DESCRIPTION
This PR strips invalid `props` keys when serializing rendered Components to be sent to the outer application. These are probably coming from JSX transpilation in the compiler worker.

Fixes #249 