### PR TITLE
Short term fix for CSS nesting syntax (use SCSS syntax)

### DIFF
--- a/packages/sandbox/src/hooks/useFileWithMonaco.ts
+++ b/packages/sandbox/src/hooks/useFileWithMonaco.ts
@@ -14,8 +14,8 @@ function useFileWithMonaco(
   let value = file?.source;
 
   if (childSourceType === 'CSS') {
-    language = 'css';
-    path += '.css';
+    language = 'scss';
+    path += '.scss';
     value = file?.css;
   }
 


### PR DESCRIPTION
Closes: https://github.com/near/bos-web-engine/issues/277

As of now, Monaco doesn't have support for native CSS nesting syntax (it shows a bunch of errors when you do). A quick, short term fix is using the built in support for `SCSS` syntax.

<img width="456" alt="Screen Shot 2024-02-14 at 11 16 05 AM" src="https://github.com/near/bos-web-engine/assets/1475067/da8a3513-63aa-4cf9-81a6-428488fd030a">
