### PR TITLE
Improved Demos

### DIFF
--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_DEFAULT_ROOT_COMPONENT=bwe-demos.near/LandingPage
+NEXT_PUBLIC_DEFAULT_ROOT_COMPONENT=webengine.near/LandingPage

--- a/packages/sandbox/src/components/FileOpener.tsx
+++ b/packages/sandbox/src/components/FileOpener.tsx
@@ -296,10 +296,10 @@ function Root({ setIsOpen }: Props) {
 
                 <ul className={s.examplesList}>
                   <li>
-                    <Text size="s">bwe-demos.near</Text>
+                    <Text size="s">webengine.near</Text>
                   </li>
                   <li>
-                    <Text size="s">bwe-demos.near/HelloWorld</Text>
+                    <Text size="s">webengine.near/LandingPage</Text>
                   </li>
                 </ul>
               </>


### PR DESCRIPTION
Closes: https://github.com/near/bos-web-engine/issues/286
Closes: https://github.com/near/bos-web-engine/issues/287

Improved styles and types for our `LandingPage` and `SocialFeedPage` components. Since we don't have `bos-cli` set up to handle CSS modules just yet, @mpeterdev had me go ahead and fork and publish these new components on `webengine.near` (using the Sandbox UI).

The `SocialFeedPage` demonstrates using a breakpoint to change spacing on smaller screens.

I went ahead and updated `NEXT_PUBLIC_DEFAULT_ROOT_COMPONENT` in Vercel as well.