### PR TITLE
Component Alpha Namespace

### DIFF
--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -95,9 +95,3 @@ export interface ComponentEntry {
   '': string;
   css: string;
 }
-
-interface SocialComponent {
-  widget: { [name: string]: string | ComponentEntry };
-}
-
-export type SocialComponentsByAuthor = { [author: string]: SocialComponent };

--- a/packages/social-db-api/src/constants.ts
+++ b/packages/social-db-api/src/constants.ts
@@ -6,7 +6,7 @@ export const MAINNET_SOCIAL_CONTRACT_ID = 'social.near';
 export const TESTNET_RPC_URL = 'https://rpc.testnet.near.org';
 export const MAINNET_RPC_URL = 'https://rpc.mainnet.near.org';
 
-export const SOCIAL_COMPONENT_NAMESPACE = 'widget';
+export const SOCIAL_COMPONENT_NAMESPACE = 'component_alpha';
 export const SOCIAL_IPFS_BASE_URL = 'https://ipfs.near.social/ipfs';
 
 // The following gas, storage, and size values were copied from NearSocial/VM:


### PR DESCRIPTION
Closes: https://github.com/near/bos-web-engine/issues/179
Closes: https://github.com/near/bos-web-engine/issues/178

One thing to keep in mind is that `deploy-components-main.yml` will still be deploying our `demos` folder for `bwe-demos.near` to the `widget` namespace due to the usage of `bos` CLI.

This means that all `bwe-demos.near` components will throw an error:

- https://bos-web-engine-git-feat-alpha-com-02bf22-near-developer-console.vercel.app/bwe-demos.near/StateAndTrust.Root
- Clicking any of the links on this page will be broken too: https://bos-web-engine-git-feat-alpha-com-02bf22-near-developer-console.vercel.app/webengine.near/NPM.Tracker

@mpeterdev we might need to fork and publish all `bwe-demos.near` components through the sandbox UI (moving everything over to `webengine.near`). I went ahead and did this for all existing `webengine.near` components.

Once we fork all components from `bwe-demos.near` to `webengine.near` - we'll just all need to be aware that we need to modify our demo components in the sandbox UI signed into `webengine.near`. Modifying the `demos` folder and pushing changes in our repo won't work until the `bos` CLI is updated.