### PR TITLE
getAccounts()

### DIFF
--- a/apps/web/src/pages/[[...root]].tsx
+++ b/apps/web/src/pages/[[...root]].tsx
@@ -1,4 +1,5 @@
 import { ComponentTree, useWebEngine } from '@bos-web-engine/application';
+import { useWallet } from '@bos-web-engine/wallet-selector-control';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
@@ -11,6 +12,7 @@ const DEFAULT_COMPONENT = process.env.NEXT_PUBLIC_DEFAULT_ROOT_COMPONENT;
 const PREACT_VERSION = '10.17.1';
 
 export default function Root() {
+  const { account } = useWallet();
   const router = useRouter();
   const { query } = router;
 
@@ -55,6 +57,7 @@ export default function Root() {
           {error && <div className="error">{error}</div>}
           <ComponentTree
             components={components}
+            currentUserAccountId={account?.accountId}
             rootComponentPath={rootComponentPath}
           />
           <Inspector />

--- a/packages/application/src/components/ComponentTree.tsx
+++ b/packages/application/src/components/ComponentTree.tsx
@@ -2,11 +2,13 @@ import { SandboxedIframe } from './SandboxedIframe';
 import { getAppDomId, getIframeId } from '../container';
 
 interface ComponentTreeParams {
+  currentUserAccountId?: string | undefined;
   components: { [componentId: string]: any };
   rootComponentPath: string;
 }
 
 export default function ComponentTree({
+  currentUserAccountId,
   components,
   rootComponentPath,
 }: ComponentTreeParams) {
@@ -29,7 +31,19 @@ export default function ComponentTree({
               componentId,
               { trust, props, componentSource, parentId, moduleImports },
             ]) => (
-              <div key={componentId} component-id={componentId}>
+              /*
+                NOTE: Including currentUserAccountId as part of the key forces the entire tree 
+                to rerender whenever the currently signed in wallet changes. This allows the 
+                getAccounts() method (provided by wallet-selector-plugin) to be called again 
+                in any components that are relying on it. This will then provide those components 
+                with the correct, current state for getAccounts() - without requiring a full page 
+                refresh.
+              */
+
+              <div
+                key={componentId + currentUserAccountId}
+                component-id={componentId}
+              >
                 <SandboxedIframe
                   id={getIframeId(componentId)}
                   trust={trust}

--- a/packages/application/src/handlers.ts
+++ b/packages/application/src/handlers.ts
@@ -55,6 +55,11 @@ export async function onApplicationMethodInvocation({
         All of the methods also require the user to be signed in with a wallet.
       */
 
+      case 'walletSelector.getAccounts': {
+        // Instead of throwing an error, we return an empty array when the user hasn't signed in yet
+        if (!wallet) return sendResponse([]);
+        return sendResponse(await wallet.getAccounts());
+      }
       case 'walletSelector.signAndSendTransaction': {
         if (!wallet)
           throw new Error('Wallet not initialized (user not signed in)');

--- a/packages/sandbox/src/components/FileExplorer.module.css
+++ b/packages/sandbox/src/components/FileExplorer.module.css
@@ -156,6 +156,10 @@
   box-sizing: border-box;
   min-width: 0;
   outline: none;
+
+  &[contenteditable] {
+    text-overflow: clip;
+  }
 }
 
 .fileIcon {

--- a/packages/sandbox/src/components/Preview.tsx
+++ b/packages/sandbox/src/components/Preview.tsx
@@ -127,6 +127,7 @@ export function Preview() {
           <ComponentTree
             key={nonce}
             components={components}
+            currentUserAccountId={account?.accountId}
             rootComponentPath={rootComponentPath}
           />
         )}

--- a/packages/wallet-selector-control/src/components/WalletSelectorControl.module.css
+++ b/packages/wallet-selector-control/src/components/WalletSelectorControl.module.css
@@ -37,6 +37,10 @@
     color: var(--color-text-2);
     font-size: 0.7rem;
   }
+
+  &:first-child {
+    padding-left: 0.25rem;
+  }
 }
 
 .avatar {

--- a/packages/wallet-selector-plugin/src/index.ts
+++ b/packages/wallet-selector-plugin/src/index.ts
@@ -9,13 +9,19 @@ declare global {
 
 type WalletSelectorPlugin = Pick<
   BrowserWalletBehaviour,
-  'signMessage' | 'signAndSendTransaction'
+  'getAccounts' | 'signMessage' | 'signAndSendTransaction'
 >;
 
 export default function initializeWalletSelectorPlugin() {
   function initWalletSelectorPlugin({
     callApplicationMethod,
   }: WebEngineContext): WalletSelectorPlugin {
+    const getAccounts: BrowserWalletBehaviour['getAccounts'] = () =>
+      callApplicationMethod({
+        args: [],
+        method: 'walletSelector.getAccounts',
+      });
+
     const signMessage: BrowserWalletBehaviour['signMessage'] = (args) =>
       callApplicationMethod({
         args: [args],
@@ -30,6 +36,7 @@ export default function initializeWalletSelectorPlugin() {
         });
 
     return {
+      getAccounts,
       signMessage,
       signAndSendTransaction,
     };


### PR DESCRIPTION
Closes: https://github.com/near/bos-web-engine/issues/311

Exposes `getAccounts` through our existing wallet selector plugin. This allows components to know what `accountId` and `publicKey` the user is signed in with (or if they aren't signed in at all, which would be an empty array).

I did need to add an adjustment to `<ComponentTree />` to re-render the entire tree when the current account changes. I left a detailed note in the source code. I believe we were going to need to make a change like this at some point regardless. Forcefully re-rendering the entire component tree when the wallet context changes (user signs in or out) should help avoid all kinds of issues for component authors down the road.

Without this change to `<ComponentTree />`, if you signed in or signed out without refreshing the page, the component state would not be updated since `getAccounts()` wouldn't be called again.

I created a demo component here: https://bos-web-engine-git-feat-wallet-se-a59606-near-developer-console.vercel.app/webengine.near/WalletSelector.CurrentAccount

I'll update our landing page to link to this component once we merge this and feel comfortable with it.

Happy to chat further about this if any concerns pop up!