### PR TITLE
fix: script injection

### DIFF
--- a/packages/application/src/react.ts
+++ b/packages/application/src/react.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type FunctionComponent } from 'react';
 
 import { deserializeProps } from './container';
 import type {
@@ -6,6 +6,18 @@ import type {
   CreateElementParams,
   ComponentDOMElement,
 } from './types';
+
+const secureCreateElement = (
+  type: string | FunctionComponent,
+  props: object,
+  ...children: any
+): ComponentDOMElement | null => {
+  if (type === 'script') {
+    return null;
+  }
+
+  return React.createElement(type, props, ...children);
+};
 
 function isChildrenAllowed(elementType: string) {
   return !(elementType in ['img']);
@@ -17,8 +29,8 @@ export function createElement({
   props,
   type,
   onMessageSent,
-}: CreateElementParams): ComponentDOMElement {
-  return React.createElement(
+}: CreateElementParams): ComponentDOMElement | null {
+  return secureCreateElement(
     type,
     deserializeProps({ id, props, onMessageSent }),
     isChildrenAllowed(type) ? children : undefined
@@ -60,10 +72,10 @@ export function createChildElements({
       !subChildren ||
       !subChildren.filter((c: any) => c !== undefined).length
     ) {
-      return React.createElement(type, childProps);
+      return secureCreateElement(type, childProps);
     }
 
-    return React.createElement(
+    return secureCreateElement(
       type,
       childProps,
       createChildElements({

--- a/packages/application/src/react.ts
+++ b/packages/application/src/react.ts
@@ -16,7 +16,20 @@ const secureCreateElement = (
     return null;
   }
 
-  return React.createElement(type, props, ...children);
+  const sanitizedProps = Object.fromEntries(
+    Object.entries(props).filter(([, value]) => {
+      if (typeof value === 'string') {
+        const v = value.trim();
+        if (v.startsWith('#') || v.startsWith('javascript:')) {
+          return false;
+        }
+      }
+
+      return true;
+    })
+  );
+
+  return React.createElement(type, sanitizedProps, ...children);
 };
 
 function isChildrenAllowed(elementType: string) {

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -13,7 +13,7 @@ import type {
 } from '@bos-web-engine/compiler';
 import type { SocialDb } from '@bos-web-engine/social-db';
 import type { Wallet } from '@near-wallet-selector/core';
-import type { DOMElement } from 'react';
+import type { ReactElement } from 'react';
 
 export interface ApplicationMethodInvocationParams {
   args: SerializedArgs;
@@ -91,7 +91,7 @@ export interface DeserializePropsParams {
   props: any;
 }
 
-export interface ComponentDOMElement extends DOMElement<any, any> {}
+export interface ComponentDOMElement extends ReactElement<any, any> {}
 
 export interface CreateElementParams {
   children?: any;

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -304,9 +304,15 @@ export class ComponentCompiler {
       ),
     ].join('\n\n');
 
+    // escape "</script>" literals to prevent interpolation issues
+    const sanitizedSource = componentSource.replaceAll(
+      /<\/script\s*>/g,
+      '<\\/script>'
+    );
+
     this.sendWorkerMessage({
       componentId,
-      componentSource,
+      componentSource: sanitizedSource,
       containerStyles: [...transformedComponents.values()]
         .map(({ css }) => css)
         .join('\n'),

--- a/packages/compiler/src/transpile.ts
+++ b/packages/compiler/src/transpile.ts
@@ -105,6 +105,7 @@ export function transpileSource({
           arguments: [Identifier | StringLiteral, ObjectExpression | undefined];
           callee: { object: Identifier; property: Identifier };
         };
+        remove: () => void;
       }) {
         const {
           arguments: args,
@@ -115,6 +116,9 @@ export function transpileSource({
           object?.name === '__Preact' && property?.name === 'createElement';
         const isElement = t.isStringLiteral(args[0]);
         if (!isCreateElement || isElement) {
+          if (isElement && (args[0] as StringLiteral).value === 'script') {
+            path.remove();
+          }
           return;
         }
 


### PR DESCRIPTION
This PR adds logic around excluding executable code via bundling or rendering:
- `<script>` tags are now stripped out of input Component source
- `</script>` literals are removed from code to prevent early termination of the `<script>` within the container iframe `srcDoc`
- `<script>` tags can no longer be created from rendered DOM (i.e. no injection via `window.postMessage({ type: "component.render" })`)
- `props` with executable JS as values are stripped out.

Fixes #226 