### PR TITLE
fix: remove filter for '#'

### DIFF
--- a/packages/application/src/react.ts
+++ b/packages/application/src/react.ts
@@ -19,8 +19,7 @@ const secureCreateElement = (
   const sanitizedProps = Object.fromEntries(
     Object.entries(props).filter(([, value]) => {
       if (typeof value === 'string') {
-        const v = value.trim();
-        if (v.startsWith('#') || v.startsWith('javascript:')) {
+        if (value.trim().startsWith('javascript:')) {
           return false;
         }
       }


### PR DESCRIPTION
This PR removes the check for a leading `#` as a `props` value as it is overly-restrictive