### PR TITLE
feat: new props interface

### DIFF
--- a/apps/demos/globals.d.ts
+++ b/apps/demos/globals.d.ts
@@ -12,5 +12,5 @@ declare global {
 
   type BWEComponent<TProps = {}> = (props: TProps & BWEComponentProps) => JSX.Element;
 
-  function Component(props: { src: string } & Record<any, any> & BWEComponentProps): JSX.Element
+  function Component(props: { bwe: { src: string; } & BWEComponentConfig } & Record<any, any>): JSX.Element
 }

--- a/apps/demos/globals.d.ts
+++ b/apps/demos/globals.d.ts
@@ -1,10 +1,16 @@
 import type { JSX } from 'react';
 
 declare global {
-  function Component(props: {
-    src: string;
-    props?: Record<any, any>;
-    trust?: { mode: string };
+  interface BWEComponentConfig {
     id?: string;
-  }): JSX.Element;
+    trust?: { mode: string };
+  }
+
+  interface BWEComponentProps {
+    bwe?: BWEComponentConfig;
+  }
+
+  type BWEComponent<TProps = {}> = (props: TProps & BWEComponentProps) => JSX.Element;
+
+  function Component(props: { src: string } & Record<any, any> & BWEComponentProps): JSX.Element
 }

--- a/packages/application/src/components/SandboxedIframe.tsx
+++ b/packages/application/src/components/SandboxedIframe.tsx
@@ -7,7 +7,6 @@ import {
   buildRequest,
   composeMessagingMethods,
   initContainer,
-  buildSafeProxy,
   composeSerializationMethods,
   composeRenderMethods,
 } from '@bos-web-engine/container';
@@ -58,7 +57,6 @@ function buildSandboxedComponent({
               containerMethods: {
                 buildEventHandler: ${buildEventHandler.toString()},
                 buildRequest: ${buildRequest.toString()},
-                buildSafeProxy: ${buildSafeProxy.toString()},
                 composeMessagingMethods: ${composeMessagingMethods.toString()},
                 composeRenderMethods: ${composeRenderMethods.toString()},
                 composeSerializationMethods: ${composeSerializationMethods.toString()},

--- a/packages/application/src/container.ts
+++ b/packages/application/src/container.ts
@@ -56,7 +56,7 @@ export function deserializeProps({
     return props;
   }
 
-  delete props.__bweMeta;
+  delete props.bwe;
 
   return Object.fromEntries(
     Object.entries(props).map(([k, v]) => {

--- a/packages/common/src/types/render.ts
+++ b/packages/common/src/types/render.ts
@@ -1,6 +1,5 @@
 export interface WebEngineMeta {
   componentId?: string;
-  isProxy?: boolean;
   parentMeta?: WebEngineMeta;
 }
 

--- a/packages/common/src/types/render.ts
+++ b/packages/common/src/types/render.ts
@@ -1,6 +1,10 @@
+import type { ComponentTrust } from './trust';
+
 export interface WebEngineMeta {
   componentId?: string;
   parentMeta?: WebEngineMeta;
+  src?: string;
+  trust?: ComponentTrust;
 }
 
 export interface KeyValuePair {
@@ -8,7 +12,7 @@ export interface KeyValuePair {
 }
 
 export interface Props extends KeyValuePair {
-  __bweMeta?: WebEngineMeta;
+  bwe?: WebEngineMeta;
   children?: any[];
   className?: string;
   id?: string;

--- a/packages/common/src/types/serialization.ts
+++ b/packages/common/src/types/serialization.ts
@@ -1,5 +1,9 @@
-import type { Props } from './render';
+import type { Props, WebEngineMeta } from './render';
 import type { ComponentTrust } from './trust';
+
+export type BOSComponentProps = Props & {
+  bwe: WebEngineMeta;
+};
 
 export interface ComponentChildMetadata {
   componentId: string;

--- a/packages/compiler/src/transpile.ts
+++ b/packages/compiler/src/transpile.ts
@@ -134,7 +134,7 @@ export function transpileSource({
          *  in a scope in which the correct props is bound to arguments[0], i.e. the Component's root
          *  scope - in the directly-returned JSX or an arrow function in the Component's root scope.
          *
-         *  TODO the correct solution is for the parser to inject the __bweMeta reference into the Component
+         *  TODO the correct solution is for the parser to inject the `bwe` reference into the Component
          *   props argument, but it would also need to be made accessible to the render site
          *
          *   TL; DR
@@ -159,7 +159,7 @@ export function transpileSource({
             t.logicalExpression(
               '&&',
               propsAccessor,
-              t.memberExpression(propsAccessor, t.identifier('__bweMeta'))
+              t.memberExpression(propsAccessor, t.identifier('bwe'))
             )
           ),
         ]);
@@ -228,7 +228,7 @@ export function transpileSource({
             const componentProps = propsExpressions.props;
             props.properties = [
               t.objectProperty(
-                t.identifier('__bweMeta'),
+                t.identifier('bwe'),
                 t.objectExpression([
                   ...bweMeta.properties,
                   ...props!.properties.filter(

--- a/packages/container/src/container.ts
+++ b/packages/container/src/container.ts
@@ -65,7 +65,7 @@ export function initContainer({
     const getComparable = (p: Props) =>
       Object.entries(p)
         .sort(([aKey], [bKey]) => (aKey === bKey ? 0 : aKey > bKey ? 1 : -1))
-        .filter(([k]) => k !== '__bweMeta')
+        .filter(([k]) => k !== 'bwe')
         .map(([key, value]) => `${key}::${value?.toString()}`)
         .join(',');
 
@@ -93,10 +93,10 @@ export function initContainer({
         }
 
         const updatedProps = { ...props, ...newProps };
-        if (!updatedProps.__bweMeta) {
-          updatedProps.__bweMeta = {};
+        if (!updatedProps.bwe) {
+          updatedProps.bwe = {};
         }
-        updatedProps.__bweMeta.componentId = componentId;
+        updatedProps.bwe.componentId = componentId;
 
         return updatedProps;
       }),

--- a/packages/container/src/index.ts
+++ b/packages/container/src/index.ts
@@ -6,6 +6,6 @@ export {
 export { initContainer } from './container';
 export { buildEventHandler } from './events';
 export { buildRequest, composeMessagingMethods } from './messaging';
-export { buildSafeProxy, composeRenderMethods } from './render';
+export { composeRenderMethods } from './render';
 export { composeSerializationMethods } from './serialize';
 export * from './types';

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -72,7 +72,8 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
     node: BWEComponentNode,
     children: ComponentChildren
   ): PlaceholderNode => {
-    const { id, src, parentMeta } = node.props.__bweMeta;
+    const { bwe, id } = node.props;
+    const { src, parentMeta } = bwe;
     const childComponentId = [src, id, parentMeta?.componentId].join('##');
 
     return {

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -1,27 +1,12 @@
-import type { Props, WebEngineMeta } from '@bos-web-engine/common';
 import type { ComponentChildren, ComponentType, VNode } from 'preact';
 
 import type {
+  BWEComponentNode,
   ComposeRenderMethodsCallback,
   ContainerComponent,
   Node,
+  PlaceholderNode,
 } from './types';
-
-type BOSComponentProps = Props & {
-  bwe: WebEngineMeta;
-};
-
-type BWEComponentNode = VNode<BOSComponentProps>;
-
-interface PlaceholderNode {
-  type: string;
-  props: {
-    id: string;
-    className: string;
-    children: ComponentChildren;
-    'data-component-src': string;
-  };
-}
 
 interface RenderedVNode extends VNode<any> {
   __k?: RenderedVNode[];
@@ -72,25 +57,31 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
     node: BWEComponentNode,
     children: ComponentChildren
   ): PlaceholderNode => {
-    const { bwe, id } = node.props;
+    const {
+      key,
+      props: { id, bwe },
+    } = node;
     const { src, parentMeta } = bwe;
-    const childComponentId = [src, id, parentMeta?.componentId].join('##');
+    // TODO remove id fallback after dev migration
+    const childComponentId = [src, key || id, parentMeta?.componentId].join(
+      '##'
+    );
 
     return {
       type: 'div',
+      key: key || id, // TODO remove id fallback after dev migration
       props: {
         id: 'dom-' + childComponentId,
         className: 'bwe-component-container',
         children,
-        'data-component-src': src,
+        'data-component-src': src!,
       },
     };
   };
 
   function parseRenderedTree(
     node: RenderedVNode | null,
-    renderedChildren?: Array<RenderedVNode | null>,
-    childIndex?: number
+    renderedChildren?: Array<RenderedVNode | null>
   ): VNode | null | Array<VNode | null> {
     if (!node || !renderedChildren) {
       return node;
@@ -147,17 +138,15 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
     if (typeof node.type !== 'function' || isComponent(node.type)) {
       return {
         type: node.type,
-        key: `${typeof node.type === 'function' ? node.type.name : node.type}-${
-          childIndex || 0
-        }`,
+        key: node.key || props.id, // TODO remove id fallback after dev migration
         props: {
           ...props,
           children: [renderedChildren]
             .flat()
             .filter((c) => !!c)
-            .map((child, i) => {
+            .map((child) => {
               if (child?.type) {
-                return parseRenderedTree(child, child?.__k, i);
+                return parseRenderedTree(child, child?.__k);
               }
 
               return child?.props;
@@ -188,14 +177,7 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
       renderedChildren
     );
 
-    return parseRenderedTree(
-      {
-        type: componentNode.type,
-        props: componentNode.props,
-        key: `bwe-component-${node.type.name}`,
-      },
-      renderedChildren
-    );
+    return parseRenderedTree(componentNode, renderedChildren);
   }
 
   const commit = (vnode: RenderedVNode) => {

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -1,8 +1,4 @@
-import type {
-  ComponentTrust,
-  Props,
-  WebEngineMeta,
-} from '@bos-web-engine/common';
+import type { Props, WebEngineMeta } from '@bos-web-engine/common';
 import type { ComponentChildren, ComponentType, VNode } from 'preact';
 
 import type {
@@ -12,11 +8,7 @@ import type {
 } from './types';
 
 type BOSComponentProps = Props & {
-  __bweMeta: WebEngineMeta & {
-    id: string;
-    src: string;
-    trust?: ComponentTrust;
-  };
+  bwe: WebEngineMeta;
 };
 
 type BWEComponentNode = VNode<BOSComponentProps>;

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -6,29 +6,10 @@ import type {
 import type { ComponentChildren, ComponentType, VNode } from 'preact';
 
 import type {
-  BuildSafeProxyCallback,
   ComposeRenderMethodsCallback,
   ContainerComponent,
   Node,
 } from './types';
-
-export const buildSafeProxy: BuildSafeProxyCallback = ({
-  props,
-  componentId,
-}) => {
-  return new Proxy(
-    { ...props, __bweMeta: { componentId, isProxy: true } },
-    {
-      get(target, key) {
-        try {
-          return (target as any)[key];
-        } catch {
-          return undefined;
-        }
-      },
-    }
-  );
-};
 
 type BOSComponentProps = Props & {
   __bweMeta: WebEngineMeta & {

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -149,8 +149,6 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
     }) => {
       return Object.entries(props).reduce(
         (newProps, [key, value]: [string, any]) => {
-          const isProxy = value?.__bweMeta?.isProxy || false;
-
           // TODO remove invalid props keys at the source
           //  (probably JSX transpilation)
           if (key === 'class' || key.includes('-')) {
@@ -179,18 +177,15 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
           if (typeof value === 'function') {
             newProps[key] = serializeCallback(key, value);
           } else {
-            let serializedValue = value;
             if (isPreactNode(value)) {
               newProps[key] = serializeNode({
                 childComponents: [],
                 node: value,
                 parentId: containerId,
               });
-            } else if (isProxy) {
-              newProps[key] = { ...serializedValue };
             } else {
               newProps[key] = deepTransform({
-                value: serializedValue,
+                value,
                 onFunction: (fn: Function, path: string) =>
                   serializeCallback(`${key}${path}`, fn),
                 onNode: (node) =>

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -358,7 +358,7 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
           type: 'div',
           props: {
             id: 'dom-' + componentId,
-            __bweMeta: {
+            bwe: {
               componentId,
             },
             className: 'container-child',

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -324,10 +324,12 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
       parentId,
       props,
     }: SerializeChildComponentParams) => {
-      const { id: instanceId, src, props: componentProps, trust } = props;
+      const { id: instanceId, bwe, ...componentProps } = props;
+      const { src, trust } = bwe || {};
+
       const componentId = buildComponentId({
         instanceId,
-        componentPath: src,
+        componentPath: src!,
         parentComponentId: parentId,
       });
 

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -1,13 +1,20 @@
-import type { Props, SerializedNode } from '@bos-web-engine/common';
+import type {
+  BOSComponentProps,
+  ComponentChildMetadata,
+  ComponentTrust,
+  Props,
+  SerializedNode,
+} from '@bos-web-engine/common';
 
 import type {
+  BWEComponentNode,
   ComposeSerializationMethodsCallback,
+  DeserializeArgsCallback,
   DeserializePropsCallback,
-  SerializePropsCallback,
+  Node,
   SerializeArgsCallback,
   SerializeNodeCallback,
-  DeserializeArgsCallback,
-  Node,
+  SerializePropsCallback,
 } from './types';
 
 export interface BuildComponentIdParams {
@@ -18,7 +25,7 @@ export interface BuildComponentIdParams {
 
 interface SerializeChildComponentParams {
   parentId: string;
-  props: Props;
+  node: BWEComponentNode & { id?: string }; // TODO remove id after dev migration
 }
 
 interface SerializedPropsCallback {
@@ -309,7 +316,7 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
       componentPath,
       parentComponentId,
     }: BuildComponentIdParams) {
-      // TODO warn on missing instanceId (<Component>'s id prop) here?
+      // TODO warn on missing instanceId (<Component>'s key prop) here?
       return [componentPath, instanceId?.toString(), parentComponentId].join(
         '##'
       );
@@ -322,10 +329,19 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
      */
     const serializeChildComponent = ({
       parentId,
-      props,
-    }: SerializeChildComponentParams) => {
-      const { id: instanceId, bwe, ...componentProps } = props;
-      const { src, trust } = bwe || {};
+      node,
+    }: SerializeChildComponentParams): {
+      child: ComponentChildMetadata;
+      placeholder: SerializedNode;
+    } => {
+      const {
+        key,
+        id,
+        props: { bwe, ...componentProps },
+      } = node;
+      const { src, trust } = bwe;
+      // TODO remove id fallback after dev migration
+      const instanceId = key || id;
 
       const componentId = buildComponentId({
         instanceId,
@@ -333,10 +349,9 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
         parentComponentId: parentId,
       });
 
-      let child;
-      try {
-        child = {
-          trust,
+      return {
+        child: {
+          trust: trust || ({ mode: 'sandboxed' } as ComponentTrust),
           props: componentProps
             ? serializeProps({
                 componentId,
@@ -344,18 +359,9 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
                 props: componentProps,
               })
             : {},
-          source: src,
+          source: src!,
           componentId,
-        };
-      } catch (error) {
-        console.warn(`failed to dispatch component load for ${parentId}`, {
-          error,
-          componentProps,
-        });
-      }
-
-      return {
-        child,
+        },
         placeholder: {
           type: 'div',
           props: {
@@ -364,7 +370,7 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
               componentId,
             },
             className: 'container-child',
-            'data-component-src': src,
+            'data-component-src': src!,
           },
         },
       };
@@ -388,7 +394,7 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
       const { type } = node;
       let serializedElementType = typeof type === 'string' ? type : '';
       const children = node?.props?.children || [];
-      let props = { ...node.props };
+      const props = { ...node.props } as BOSComponentProps;
       delete props.children;
 
       let unifiedChildren = Array.isArray(children) ? children : [children];
@@ -409,9 +415,10 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
           throw new Error(`unrecognized Component function ${type.name}`);
         }
 
+        const componentNode = { ...node, props } as BWEComponentNode;
         const { child, placeholder } = serializeChildComponent({
           parentId,
-          props,
+          node: componentNode,
         });
 
         if (child) {

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -150,7 +150,6 @@ export interface InitContainerParams {
   containerMethods: {
     buildEventHandler: (params: ProcessEventParams) => Function;
     buildRequest: BuildRequestCallback;
-    buildSafeProxy: BuildSafeProxyCallback;
     composeMessagingMethods: ComposeMessagingMethodsCallback;
     composeRenderMethods: ComposeRenderMethodsCallback;
     composeSerializationMethods: ComposeSerializationMethodsCallback;
@@ -233,10 +232,3 @@ export interface DispatchRenderEventParams {
 export type DispatchRenderEventCallback = (
   params: DispatchRenderEventParams
 ) => void;
-
-interface BuildSafeProxyParams {
-  props: Props;
-  componentId: string;
-}
-
-export type BuildSafeProxyCallback = (params: BuildSafeProxyParams) => object;

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  BOSComponentProps,
   ComponentChildMetadata,
   ComponentTrust,
   ExternalCallbackInvocation,
@@ -6,7 +7,7 @@ import type {
   SerializedArgs,
   SerializedNode,
 } from '@bos-web-engine/common';
-import { FunctionComponent, VNode } from 'preact';
+import type { ComponentChildren, FunctionComponent, VNode } from 'preact';
 
 export type BuildRequestCallback = () => CallbackRequest;
 
@@ -232,3 +233,16 @@ export interface DispatchRenderEventParams {
 export type DispatchRenderEventCallback = (
   params: DispatchRenderEventParams
 ) => void;
+
+export type BWEComponentNode = VNode<BOSComponentProps>;
+
+export interface PlaceholderNode {
+  type: string;
+  key: string;
+  props: {
+    id: string;
+    className: string;
+    children: ComponentChildren;
+    'data-component-src': string;
+  };
+}

--- a/packages/sandbox/src/constants.ts
+++ b/packages/sandbox/src/constants.ts
@@ -64,18 +64,18 @@ export const MONACO_EXTERNAL_LIBRARIES: MonacoExternalLibrary[] = [
         export default classes;
       }
 
-      type BWEComponent<TProps = {}> = (props: {
+      interface BWEComponentConfig {
         id?: string;
-        props?: TProps;
         trust?: { mode: string };
-      }) => JSX.Element;
+      }
 
-      function Component(props: {
-        src: string;
-        props?: Record<any, any>;
-        trust?: { mode: string };
-        id?: string;
-      }): JSX.Element;
+      interface BWEComponentProps {
+        bwe?: BWEComponentConfig;
+      }
+
+      type BWEComponent<TProps = {}> = (props: TProps & BWEComponentProps) => JSX.Element;
+
+      function Component(props: { src: string } & Record<any, any> & BWEComponentProps): JSX.Element
     }`,
   },
 ];

--- a/packages/sandbox/src/constants.ts
+++ b/packages/sandbox/src/constants.ts
@@ -75,7 +75,7 @@ export const MONACO_EXTERNAL_LIBRARIES: MonacoExternalLibrary[] = [
 
       type BWEComponent<TProps = {}> = (props: TProps & BWEComponentProps) => JSX.Element;
 
-      function Component(props: { src: string } & Record<any, any> & BWEComponentProps): JSX.Element
+      function Component(props: { bwe: { src: string; } & BWEComponentConfig } & Record<any, any>): JSX.Element
     }`,
   },
 ];

--- a/packages/sandbox/src/constants.ts
+++ b/packages/sandbox/src/constants.ts
@@ -153,7 +153,7 @@ function HelloWorld() {
       <div className={s.examples}>
         <div className={s.card}>
           <h3>Embedding another BWE component</h3>
-          <Message props={{ message: 'Hello world!' }} />
+          <Message message="Hello world!" />
         </div>
         <div className={s.card}>
           <h3>React <code>useState</code></h3>


### PR DESCRIPTION
This PR updates the props interface to consolidate the web engine config props into a single object, allowing Component props to be inlined at the top level instead of under a `props` key (fixes #261). Additionally, the top-level `id` prop has been replaced by `key` (fixes #335).

All changes are backward compatible, though the sandbox IDE typing will reflect the new usage - legacy usage will be squiggly'd.

See example:
```jsx
import { useState } from 'react';

import Message from './Message';
import s from './styles.module.css';

function HelloWorld() {
  const [count, setCount] = useState(0);

  return (
    <div className={s.wrapper}>
      <h1>Welcome!</h1>

      {/*
        This legacy usage will be supported at runtime but will now throw TS errors
        Warnings will be displayed in the console
      */}
      <Message
        id="legacy-default"
        props={{ message: 'legacy default' }}
      />
      <Message
        id="legacy-sandboxed"
        trust={{mode:'sandboxed'}}
        props={{ message: 'legacy sandboxed' }}
      />
      <Message
        id="legacy-trusted"
        trust={{mode:'trusted'}}
        props={{ message: 'legacy trusted' }}
      />
      
      {/*
        This is the new interface that will be used going forward
      */}
      <Message
        key="new-default"
        message="new default"
      />
      <Message
        key="new-sandboxed"
        bwe={{ trust: { mode: 'sandboxed' } }}
        message="new sandboxed"
      />
      <Message
        key="new-trusted"
        bwe={{ trust: { mode: 'trusted' } }}
        message="new trusted"
      />
      <button type="button" onClick={() => setCount((value) => value + 1)}>
        Increase Count: {count}
      </button>
    </div>
  );
}

export default HelloWorld as BWEComponent;
```