### PR TITLE
feat: deprecate legacy props

### DIFF
--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_DEFAULT_ROOT_COMPONENT=webengine.near/LandingPage
+NEXT_PUBLIC_DEFAULT_ROOT_COMPONENT=bwe-demos.near/LandingPage

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -59,17 +59,14 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
   ): PlaceholderNode => {
     const {
       key,
-      props: { id, bwe },
+      props: { bwe },
     } = node;
     const { src, parentMeta } = bwe;
-    // TODO remove id fallback after dev migration
-    const childComponentId = [src, key || id, parentMeta?.componentId].join(
-      '##'
-    );
+    const childComponentId = [src, key, parentMeta?.componentId].join('##');
 
     return {
       type: 'div',
-      key: key || id, // TODO remove id fallback after dev migration
+      key: key,
       props: {
         id: 'dom-' + childComponentId,
         className: 'bwe-component-container',
@@ -138,7 +135,7 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
     if (typeof node.type !== 'function' || isComponent(node.type)) {
       return {
         type: node.type,
-        key: node.key || props.id, // TODO remove id fallback after dev migration
+        key: node.key,
         props: {
           ...props,
           children: [renderedChildren]

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -25,7 +25,7 @@ export interface BuildComponentIdParams {
 
 interface SerializeChildComponentParams {
   parentId: string;
-  node: BWEComponentNode & { id?: string }; // TODO remove id after dev migration
+  node: BWEComponentNode;
 }
 
 interface SerializedPropsCallback {
@@ -335,13 +335,10 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
       placeholder: SerializedNode;
     } => {
       const {
-        key,
-        id,
+        key: instanceId,
         props: { bwe, ...componentProps },
       } = node;
       const { src, trust } = bwe;
-      // TODO remove id fallback after dev migration
-      const instanceId = key || id;
 
       const componentId = buildComponentId({
         instanceId,


### PR DESCRIPTION
This PR deprecates support for legacy style props for Components, i.e.
- specifying `id` instead of `key` as a top-level prop
- putting Component props under `props` - these should be specified as top-level prop keys
- specifying `trust` or `src` as top-level props - these should go under the `bwe` prop


As a breaking change, this should only be merged once the changes have been announced and devs have had time to migrate. Both styles are supported in the interim.