### PR TITLE
Add BOS loader missing css

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -349,8 +349,8 @@ export class ComponentCompiler {
     )) {
       // TODO remove once data is being returned in expected shape
       // @ts-expect-error
-      const { code: component } = componentSource;
-      this.bosSourceCache.set(componentPath, Promise.resolve({ component }));
+      const { code: component, css } = componentSource;
+      this.bosSourceCache.set(componentPath, Promise.resolve({ component, css }));
     }
   }
 }


### PR DESCRIPTION
Our integration with `bos-loader` was missing the css of the component. 
It would cause an error saying styles not defined, because the compiler was not reading css from the bos loader response (only the `component`).
This PR fixes css support for `bos-loader` in the compiler.

Fixed while pair programming with @andy-haynes 