### PR TITLE
feat: remove superfluous compiler init

### DIFF
--- a/packages/application/src/hooks/useWebEngineSandbox.ts
+++ b/packages/application/src/hooks/useWebEngineSandbox.ts
@@ -13,7 +13,6 @@ export function useWebEngineSandbox({
 }: UseWebEngineSandboxParams) {
   const [nonce, setNonce] = useState('');
   const preactVersion = config.preactVersion;
-  const enableBlockHeightVersioning = config.flags?.enableBlockHeightVersioning;
 
   const { appendStylesheet, resetContainerStylesheet } = useCss();
   const compiler = useCompiler({ config, localComponents });
@@ -48,13 +47,6 @@ export function useWebEngineSandbox({
     setNonce(`${rootComponentPath}:${Date.now().toString()}`);
 
     compiler?.postMessage({
-      action: 'init',
-      localComponents,
-      preactVersion,
-      enableBlockHeightVersioning,
-    });
-
-    compiler?.postMessage({
       action: 'execute',
       componentId: rootComponentPath,
     });
@@ -65,7 +57,6 @@ export function useWebEngineSandbox({
     preactVersion,
     rootComponentPath,
     setComponents,
-    enableBlockHeightVersioning,
   ]);
 
   return {


### PR DESCRIPTION
This PR removes the superfluous call to the compiler worker's `init` method in the `useWebEngineSandbox` hook. Since this method is now called as part of the `useCompiler` hook with overlapping dependencies, the call in `useWebEngineSandbox` is at best a no-op and at worst creates a race condition.

Potential fix for #382 