### PR TITLE
fix buttons in demos by making them trusted

### DIFF
--- a/apps/demos/src/AlphaDashboardPage.tsx
+++ b/apps/demos/src/AlphaDashboardPage.tsx
@@ -266,6 +266,7 @@ function AlphaDashboard() {
           {!showAllDevelopers && (developers?.length ?? 0) > DISPLAY_LIMIT && (
             <div className={s.cardFooter}>
               <Button
+                bwe={{ trust: { mode: 'trusted' } }}
                 key="show-all-developers"
                 onClick={() => setSowAllDevelopers(true)}
               >
@@ -344,6 +345,7 @@ function AlphaDashboard() {
           {!showAllComponents && (components?.length ?? 0) > DISPLAY_LIMIT && (
             <div className={s.cardFooter}>
               <Button
+                bwe={{ trust: { mode: 'trusted' } }}
                 key="show-all-components"
                 onClick={() => setSowAllComponents(true)}
               >

--- a/apps/demos/src/SocialFeedPage.tsx
+++ b/apps/demos/src/SocialFeedPage.tsx
@@ -114,7 +114,11 @@ function SocialFeedPage() {
         </div>
 
         <div className={s.footer}>
-          <Button onClick={loadMorePosts} disabled={loading}>
+          <Button
+            bwe={{ trust: { mode: 'trusted' } }}
+            onClick={loadMorePosts}
+            disabled={loading}
+          >
             Load More
           </Button>
         </div>


### PR DESCRIPTION
We are using `Button` components with a children prop but the children prop only works for trusted components at the moment

This is a worthwhile optimization anyways, so no need to revert once the children prop is supported on sandboxed components