### PR TITLE
fix: construct component IDs on demand

### DIFF
--- a/packages/common/src/types/render.ts
+++ b/packages/common/src/types/render.ts
@@ -1,7 +1,8 @@
 import type { ComponentTrust } from './trust';
 
 export interface WebEngineMeta {
-  componentId?: string;
+  componentId?: string; // TODO remove this field and only compute from src + key + parentMeta*
+  key?: string;
   parentMeta?: WebEngineMeta;
   src?: string;
   trust?: ComponentTrust;

--- a/packages/compiler/src/transpile.ts
+++ b/packages/compiler/src/transpile.ts
@@ -170,6 +170,10 @@ export function transpileSource({
           true
         );
 
+        const keyProp = (props.properties as ObjectProperty[]).find(
+          ({ key }) => t.isIdentifier(key) && (key as Identifier).name === 'key'
+        ) as ObjectProperty;
+
         const bweMeta = t.objectExpression([
           t.objectProperty(
             t.identifier('parentMeta'),
@@ -179,6 +183,9 @@ export function transpileSource({
               t.memberExpression(propsAccessor, t.identifier('bwe'))
             )
           ),
+          ...(keyProp
+            ? [t.objectProperty(t.identifier('key'), keyProp.value)]
+            : []),
         ]);
 
         const propsExpressions = props.properties.reduce(

--- a/packages/container/src/render.ts
+++ b/packages/container/src/render.ts
@@ -1,3 +1,4 @@
+import { WebEngineMeta } from '@bos-web-engine/common';
 import type { ComponentChildren, ComponentType, VNode } from 'preact';
 
 import type {
@@ -53,6 +54,16 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
     }
   };
 
+  const buildComponentId = (meta?: WebEngineMeta): string => {
+    if (!meta) {
+      return '';
+    }
+
+    return `${meta.src}##${meta.key || ''}##${buildComponentId(
+      meta.parentMeta
+    )}`;
+  };
+
   const buildBWEComponentNode = (
     node: BWEComponentNode,
     children: ComponentChildren
@@ -61,17 +72,16 @@ export const composeRenderMethods: ComposeRenderMethodsCallback = ({
       key,
       props: { bwe },
     } = node;
-    const { src, parentMeta } = bwe;
-    const childComponentId = [src, key, parentMeta?.componentId].join('##');
+    const childComponentId = buildComponentId(bwe);
 
     return {
       type: 'div',
-      key: key,
+      key,
       props: {
         id: 'dom-' + childComponentId,
         className: 'bwe-component-container',
         children,
-        'data-component-src': src!,
+        'data-component-src': bwe.src!,
       },
     };
   };


### PR DESCRIPTION
This PR fixes component IDs for trusted Components. By combining the Component path (known at build time) and the Component `key` along with the path/`key` combinations for its ancestors traced up to the root Component. Currently this only gets set at the root container, which this change fixes by constructing the Component ID recursively at render time.

Current behavior: https://bos-web-engine.vercel.app/bwe-demos.near/StateAndTrust.Root?showContainerBoundaries=false
Fixed behavior: https://bos-web-engine-git-fix-component-7c1578-near-developer-console.vercel.app/bwe-demos.near/StateAndTrust.Root?showContainerBoundaries=false

E.g. for this Component structure
```js
<Parent key="p" bwe={{ trust: { mode: 'trusted-author' } }}>
  <Child key="c" />
</Parent>
```

The ID for `Child` is currently `bwe.near/Child##c##`, but after this change becomes `bwe.near/Child##c##bwe.near/Parent##p`