### PR TITLE
fix: CSS not guaranteed on Component responses

### DIFF
--- a/packages/compiler/src/source.ts
+++ b/packages/compiler/src/source.ts
@@ -19,7 +19,7 @@ function prepareSourceWithBlockHeight(
       const sourceKey = `${entryKey}/${componentKey}`;
       sources[sourceKey] = {
         component: componentValue[''][''],
-        css: componentValue.css[''],
+        css: componentValue.css?.[''],
         blockHeight: componentValue[BLOCK_HEIGHT_KEY],
       };
     });


### PR DESCRIPTION
This PR updates the accessor for the `css` field on SocialDB responses to not assume the existence of a key.