### PR TITLE
feat: use `esm.sh` tree shaking params

### DIFF
--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -264,7 +264,7 @@ const aggregateModuleImports = (imports: ImportExpression[]): ImportsByType => {
  * @param modulePath module import path
  * @param references set of destructured references for tree shaking
  */
-export const buildModulePackageUrl = ({
+const buildModulePackageUrl = ({
   moduleName,
   modulePath,
   references,

--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -264,11 +264,15 @@ const aggregateModuleImports = (imports: ImportExpression[]): ImportsByType => {
  * @param modulePath module import path
  * @param references set of destructured references for tree shaking
  */
-export const buildModulePackageUrl = (
-  moduleName: string,
-  modulePath: string,
-  references: string[]
-) => {
+export const buildModulePackageUrl = ({
+  moduleName,
+  modulePath,
+  references,
+}: {
+  moduleName: string;
+  modulePath: string;
+  references: string[];
+}) => {
   if (modulePath.startsWith('https://')) {
     return {
       moduleName,
@@ -306,13 +310,14 @@ export const buildContainerModuleImports = (
         .filter(({ isDestructured }) => isDestructured)
         .map(({ reference }) => reference!);
 
-      const importMapEntries = buildModulePackageUrl(
+      const importMapEntries = buildModulePackageUrl({
         moduleName,
         modulePath,
-        destructuredReferences.length === imports.length
-          ? destructuredReferences
-          : []
-      );
+        references:
+          destructuredReferences.length === imports.length
+            ? destructuredReferences
+            : [],
+      });
 
       if (!importMapEntries) {
         return importMap;


### PR DESCRIPTION
This PR updates the `esm.sh` package URL to use the `exports` query string, enabling tree shaking for imported modules. URLs will now specify all destructured imports across the container for a given package.

Fixes #405 