### PR TITLE
refactor: remove superfluous callbacks argument

### DIFF
--- a/packages/container/src/callbacks.ts
+++ b/packages/container/src/callbacks.ts
@@ -71,7 +71,6 @@ export function invokeExternalContainerCallback({
 
         postCallbackInvocationMessage({
           args: childArgs,
-          callbacks,
           containerId,
           method: callbackIdentifier,
           requestId: invocationId,
@@ -91,14 +90,12 @@ export function invokeExternalContainerCallback({
  * @param callbacks The set of callbacks defined on the target Component
  * @param containerId ID of the container invoking the method
  * @param initExternalCallbackInvocation Function to initialize a callback invocation request
- * @param invokeInternalCallback Function to execute the specified function in the current Component's context
  * @param method The name of the callback to be invoked
  * @param postCallbackInvocationMessage Request invocation on external Component via window.postMessage
  * @param serializeArgs Function to serialize arguments passed to window.postMessage
  */
 export function invokeApplicationCallback<T>({
   args,
-  callbacks,
   containerId,
   initExternalCallbackInvocation,
   method,
@@ -108,7 +105,6 @@ export function invokeApplicationCallback<T>({
   const { invocation, invocationId } = initExternalCallbackInvocation<T>();
   postCallbackInvocationMessage({
     args,
-    callbacks,
     containerId,
     method,
     requestId: invocationId,

--- a/packages/container/src/messaging.ts
+++ b/packages/container/src/messaging.ts
@@ -34,7 +34,6 @@ export function composeMessagingMethods() {
 
   function postCallbackInvocationMessage({
     args,
-    callbacks,
     containerId,
     method,
     requestId,
@@ -42,7 +41,7 @@ export function composeMessagingMethods() {
     targetId,
   }: PostMessageComponentCallbackInvocationParams): void {
     postMessage<ComponentCallbackInvocation>({
-      args: serializeArgs({ args, callbacks, containerId }),
+      args: serializeArgs({ args, containerId }),
       method,
       containerId,
       requestId,

--- a/packages/container/src/serialize.ts
+++ b/packages/container/src/serialize.ts
@@ -228,7 +228,6 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
 
     const serializeArgs: SerializeArgsCallback = ({
       args,
-      callbacks,
       containerId,
     }) => {
       return (args || []).map((arg) => {
@@ -237,7 +236,7 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
         }
 
         if (Array.isArray(arg)) {
-          return serializeArgs({ args: arg, callbacks, containerId });
+          return serializeArgs({ args: arg, containerId });
         }
 
         if (typeof arg === 'object') {
@@ -245,7 +244,6 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
           return Object.fromEntries(
             serializeArgs({
               args: Object.values(arg),
-              callbacks,
               containerId,
             }).map((value, i) => [argKeys[i], value])
           );
@@ -280,7 +278,6 @@ export const composeSerializationMethods: ComposeSerializationMethodsCallback =
         // and must be cached in the component iframe
         postCallbackInvocationMessage({
           args,
-          callbacks,
           containerId,
           method: callbackIdentifier,
           requestId: invocationId,

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -56,7 +56,6 @@ export type PostMessageComponentInvocationCallback = (
 
 export interface PostMessageComponentCallbackInvocationParams {
   args: any[];
-  callbacks: CallbackMap;
   containerId: string;
   method: string;
   requestId: string;
@@ -183,7 +182,6 @@ export type SerializeArgsCallback = (
 ) => SerializedArgs;
 export interface SerializeArgsParams {
   args: any[];
-  callbacks: CallbackMap;
   containerId: string;
 }
 


### PR DESCRIPTION
This PR refactors the `serializeArgs` method to remove the `callbacks` map argument. Container-level callbacks are already passed into the parent closure scope, so including them as direct parameters is unnecessarily confusing.