### PR TITLE
Revert "feat: use `esm.sh` tree shaking params"

### DIFF
--- a/packages/compiler/src/import.ts
+++ b/packages/compiler/src/import.ts
@@ -262,17 +262,11 @@ const aggregateModuleImports = (imports: ImportExpression[]): ImportsByType => {
  * Build the importmap URL based on package name/URL
  * @param moduleName module name specified in the import statement
  * @param modulePath module import path
- * @param references set of destructured references for tree shaking
  */
-const buildModulePackageUrl = ({
-  moduleName,
-  modulePath,
-  references,
-}: {
-  moduleName: string;
-  modulePath: string;
-  references: string[];
-}) => {
+export const buildModulePackageUrl = (
+  moduleName: string,
+  modulePath: string
+) => {
   if (modulePath.startsWith('https://')) {
     return {
       moduleName,
@@ -280,20 +274,9 @@ const buildModulePackageUrl = ({
     };
   }
 
-  const queryStringParams = new Map([
-    ['alias', 'react:preact/compat'],
-    ['external', 'preact'],
-  ]);
-
-  if (references.length) {
-    queryStringParams.set('exports', references.join(','));
-  }
-
   return {
     moduleName,
-    url: `https://esm.sh/${moduleName}?${[...queryStringParams.entries()]
-      .map((entry) => entry.join('='))
-      .join('&')}`,
+    url: `https://esm.sh/${moduleName}?alias=react:preact/compat&external=preact`,
   };
 };
 
@@ -305,19 +288,8 @@ export const buildContainerModuleImports = (
   containerModuleImports: ModuleImport[]
 ) => {
   const importedModules = containerModuleImports.reduce(
-    (importMap, { moduleName, modulePath, imports }) => {
-      const destructuredReferences = imports
-        .filter(({ isDestructured }) => isDestructured)
-        .map(({ reference }) => reference!);
-
-      const importMapEntries = buildModulePackageUrl({
-        moduleName,
-        modulePath,
-        references:
-          destructuredReferences.length === imports.length
-            ? destructuredReferences
-            : [],
-      });
+    (importMap, { moduleName, modulePath }) => {
+      const importMapEntries = buildModulePackageUrl(moduleName, modulePath);
 
       if (!importMapEntries) {
         return importMap;


### PR DESCRIPTION
Reverts near/bos-web-engine#407

I've noticed this breaking compatibility with several packages now (e.g. `zustand`). It looks like poor support on the esm.sh side (see https://esm.sh/v135/zustand@4.5.2?alias=react:preact/compat&external=preact&exports=create -> [indirect dep](https://esm.sh/v135/zustand@4.5.2/X-YS9yZWFjdDpwcmVhY3QvY29tcGF0CmUvcHJlYWN0CnRzL2NyZWF0ZQ/es2022/vanilla.js) (trying to import non-existent`create`), but needs more investigation.