### PR TITLE
fix: render at the Component/container level

### DIFF
--- a/apps/demos/src/NPM/Tracker.tsx
+++ b/apps/demos/src/NPM/Tracker.tsx
@@ -17,12 +17,27 @@ const functionalAsExpected: PackageCompatibility[] = [
     demoLink: '/bwe-demos.near/NPM.React.Hooks.UseMemo?showCode=true',
   },
   {
+    name: 'React Hook useRef',
+    demoLink: '/bwe-demos.near/NPM.React.Hooks.UseRef?showCode=true',
+  },
+  {
     name: 'React Syntax Highlighter',
     demoLink: '/bwe-demos.near/NPM.ReactSyntaxHighlighter?showCode=true',
   },
   {
     name: 'uuid',
     demoLink: '/bwe-demos.near/NPM.Uuid?showCode=true',
+  },
+  {
+    name: 'Zustand',
+    demoLink: '/bwe-demos.near/NPM.Zustand?showCode=true',
+    note: (
+      <span>
+        BOS Web Engine also plans to support cross-component global state
+        management:{' '}
+        <a href="https://github.com/near/bos-web-engine/issues/18">#18</a>
+      </span>
+    ),
   },
 ];
 
@@ -36,25 +51,9 @@ const functionalWithCaveat: PackageCompatibility[] = [
 
 const partialSupport: PackageCompatibility[] = [];
 
-const notCompatible: PackageCompatibility[] = [
-  {
-    name: 'Zustand',
-    demoLink: '/bwe-demos.near/NPM.Zustand?showCode=true',
-    note: (
-      <span>
-        BOS Web Engine plans to support cross-component global state management:{' '}
-        <a href="https://github.com/near/bos-web-engine/issues/18">#18</a>
-      </span>
-    ),
-  },
-];
+const notCompatible: PackageCompatibility[] = [];
 
-const needsTesting: PackageCompatibility[] = [
-  {
-    name: 'React Hook useRef',
-    demoLink: '/bwe-demos.near/NPM.React.Hooks.UseRef?showCode=true',
-  },
-];
+const needsTesting: PackageCompatibility[] = [];
 
 export default function () {
   return (

--- a/packages/application/src/components/SandboxedIframe.tsx
+++ b/packages/application/src/components/SandboxedIframe.tsx
@@ -84,7 +84,14 @@ function buildSandboxedComponent({
 
             const oldCommit = __Preact.options.__c;
             __Preact.options.__c = (vnode, commitQueue) => {
-              commit(vnode);
+              // traverse the vnode's ancestry until the root node is reached or a Component is found
+              // Preact renders only the changed subtree, but the outer application renders at the container level
+              let componentNode = vnode;
+              while (componentNode.__ !== null && componentNode.type.isRootContainerComponent === undefined) {
+                componentNode = vnode.__;
+              }
+
+              commit(componentNode);
               oldCommit?.(vnode, commitQueue);
             };
   


### PR DESCRIPTION
This PR updates the container render logic to request renders at the Component level. When the `commit` hook is triggered on render, the target vnode is the root for the DOM subtree that changed. However the outer application only recognizes changes at the Component/container level. This means if the rendered vnode is the descendant of a Component, that subtree render will replace the entire Component DOM in the outer window. E.g. given

```jsx
const A = () => (<span>A</span>);
const B = () => (<span>B</span>);
...
<>
  <A />
  <B />
</>
```
The initial render would print both `A` and `B`, but if `<A />` were to re-render then only `A` would be printed. Since the outer application treats all render requests as coming directly from a Component, the updated descendant element overwrites the Component's DOM entirely.

Ideally this subtree rendering _would_ be supported, but this requires a more sophisticated approach to synchronize state across containers and the outer DOM. It seems unlikely that this would yield demonstrable performance benefits in the current implementation, although it may become a less daunting task as the render pipeline matures.

Fixes #399 (https://bos-web-engine-git-fix-399-compon-03c7d9-near-developer-console.vercel.app/bwe-demos.near/NPM.Zustand?showCode=true 🎉 )