### PR TITLE
Use archival rpc calls if the block id is specified

### DIFF
--- a/packages/social-db/src/constants.ts
+++ b/packages/social-db/src/constants.ts
@@ -5,6 +5,8 @@ export const MAINNET_SOCIAL_CONTRACT_ID = 'social.near';
 
 export const TESTNET_RPC_URL = 'https://rpc.testnet.near.org';
 export const MAINNET_RPC_URL = 'https://rpc.mainnet.near.org';
+export const ARCHIVAL_MAINNET_RPC_URL = 'https://archival-rpc.mainnet.near.org';
+export const ARCHIVAL_TESTNET_RPC_URL = 'https://archival-rpc.testnet.near.org';
 
 export const SOCIAL_COMPONENT_NAMESPACE = 'component_alpha';
 export const SOCIAL_IPFS_BASE_URL = 'https://ipfs.near.social/ipfs';

--- a/packages/social-db/src/social-db.ts
+++ b/packages/social-db/src/social-db.ts
@@ -10,6 +10,8 @@ import type {
 import { Big } from 'big.js';
 
 import {
+  ARCHIVAL_MAINNET_RPC_URL,
+  ARCHIVAL_TESTNET_RPC_URL,
   EXTRA_STORAGE_BALANCE,
   INITIAL_ACCOUNT_STORAGE_BALANCE,
   MAINNET_RPC_URL,
@@ -50,6 +52,8 @@ export class SocialDb {
 
   private testnetProvider: JsonRpcProvider;
   private mainnetProvider: JsonRpcProvider;
+  private archivalMainnetProvider: JsonRpcProvider;
+  private archivalTestnetProvider: JsonRpcProvider;
 
   /**
    * Interact with the `social.near` contract (Social DB).
@@ -77,6 +81,14 @@ export class SocialDb {
     this.mainnetProvider = new JsonRpcProvider({
       url: MAINNET_RPC_URL,
     });
+
+    this.archivalMainnetProvider = new JsonRpcProvider({
+      url: ARCHIVAL_MAINNET_RPC_URL,
+    });
+
+    this.archivalTestnetProvider = new JsonRpcProvider({
+      url: ARCHIVAL_TESTNET_RPC_URL,
+    });
   }
 
   private get contractId() {
@@ -92,6 +104,11 @@ export class SocialDb {
   private get provider() {
     if (this.networkId === 'mainnet') return this.mainnetProvider;
     return this.testnetProvider;
+  }
+
+  private get archivalProvider() {
+    if (this.networkId === 'mainnet') return this.archivalMainnetProvider;
+    return this.archivalTestnetProvider;
   }
 
   private get walletSelectorState() {
@@ -399,7 +416,10 @@ export class SocialDb {
     }
 
     try {
-      const response = await this.provider.query<CodeResult>(request);
+      const response = await (blockId
+        ? this.archivalProvider
+        : this.provider
+      ).query<CodeResult>(request);
       const responseData = parseJsonRpcResponse(response.result) as T;
 
       this.log({


### PR DESCRIPTION
If there is a specified block height (block id) the regular rpc call might not always return the component data.
Using the archival rpc url resolves this issue. 

To test this fix, please make sure you have `Enable block height versioning` flag set to `true` in the Dev Tools.

```tsx
import BlockHeightWithFlagTest from 'near://pavel-pagoda.near/BlockHeightWithFlagTest@115989105';
import BlockHeightWithFlagTestLatest from 'near://pavel-pagoda.near/BlockHeightWithFlagTest';

export default function () {
  return (
    <div>
      <h1>Sandbox with a block height:</h1>
      <BlockHeightWithFlagTest />
      <hr />
      <h1>Sandbox latest:</h1>
      <BlockHeightWithFlagTestLatest />
    </div>
  );
}
```

<img width="729" alt="image" src="https://github.com/near/bos-web-engine/assets/156711570/1a0d3698-7564-49ad-9db5-1aa45e5130a8">
 

Fixes https://github.com/near/bos-web-engine/issues/404