### PR TITLE
Fix infinite loop on the container subtree run

### DIFF
--- a/packages/application/src/components/SandboxedIframe.tsx
+++ b/packages/application/src/components/SandboxedIframe.tsx
@@ -88,7 +88,7 @@ function buildSandboxedComponent({
               // Preact renders only the changed subtree, but the outer application renders at the container level
               let componentNode = vnode;
               while (componentNode.__ !== null && componentNode.type.isRootContainerComponent === undefined) {
-                componentNode = vnode.__;
+                componentNode = componentNode.__;
               }
 
               commit(componentNode);


### PR DESCRIPTION
This one-liner is fixing the infinite loop, causing the browser page to freeze.

Before merging this PR, this component would hit a loop after hitting the button to increment a value:

```tsx
import { useState } from 'react';

function Child() {
  const [countChild, setCountChild] = useState(0);
  const handleClick = () => setCountChild((x) => x + 1);

  return (
    <div>
      <button onClick={handleClick}>++</button>
      child: {countChild}
    </div>
  );
}

export default function () {
  return (
    <div>
      <h1>Callback</h1>
      <Child />
    </div>
  );
}
```

This fix resolves the issue.